### PR TITLE
Updating the version number for WP 6.3 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,12 @@
 # Change log
 
-## [[1.4.9]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/1.4.9) - In Development
+## [[1.4.9]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/1.4.9) - 2023-08-09
 
 ### Added
 - Adding in suport for the read more block while using the Block Editor.
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
 
 ## [[1.4.8]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/1.4.8) - 2023-04-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tour-operator",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Tour Operators for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, tour operator, tours, travel, travel-agency
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.2
-Stable tag: 1.4.8
+Stable tag: 1.4.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -5,7 +5,7 @@
  * Description: The LSX Tour Operator plugin core contains the Accommodation, Destination and Tour post types. Use these core post types to build day-by-day tour itineraries that map out of the progress of each tour through the various accommodations and destinations that are stayed at along the way.
  * Tags: tour operator, tour operators, tour, tours, tour itinerary, tour itineraries, accommodation, accommodation listings, destinations, regions, tourism, lsx
  * Author: LightSpeed
- * Version: 1.4.8
+ * Version: 1.4.9
  * Author URI: https://www.lsdev.biz/
  * License:     GPL3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -21,7 +21,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_TO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_TO_CORE', __FILE__ );
 define( 'LSX_TO_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_TO_VER', '1.4.8' );
+define( 'LSX_TO_VER', '1.4.9' );
 
 // Post Expirator.
 define( 'LSX_TO_POSTEXPIRATOR_DATEFORMAT', esc_html__( 'l F jS, Y', 'tour-operator' ) );
@@ -34,9 +34,3 @@ require_once LSX_TO_PATH . 'tour-operator-bootstrap.php';
  * Block Initializer.
  */
 require_once LSX_TO_PATH . 'src/init.php';
-
-// Register activation hook.
-/*register_activation_hook( LSX_TO_CORE, array(
-	'Tour_Operator',
-	'register_activation_hook',
-) );*/


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag
