### PR TITLE
Fixed the multiple select2 box bloat, causing slow pageloads.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.4.10]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/1.4.10) - 2024-
+
+### Fixes
+- Fixed the multiple select2 box bloat, causing slow pageloads.
+
 ## [[1.4.9]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/1.4.9) - 2023-08-09
 
 ### Fixes

--- a/includes/classes/class-metaboxes.php
+++ b/includes/classes/class-metaboxes.php
@@ -33,6 +33,8 @@ class Metaboxes extends Frame {
 	public function __construct() {
 		parent::__construct();
 		add_filter( 'cmb_meta_boxes', array( $this, 'metaboxes' ) );
+
+		add_filter( 'cmb_admin_display_field_values_post_select', array( $this, 'unique_arrays' ), 10, 1 );
 	}
 
 	/**
@@ -60,4 +62,18 @@ class Metaboxes extends Frame {
 		$this->object[ $slug ] = $config;
 	}
 
+	/**
+	 * Remove Duplicate IDS from the post select fields.
+	 *
+	 * @param array $values
+	 * @return array
+	 */
+	public function unique_arrays( $values ) {
+
+		if ( ! empty( $values ) && is_array( $values ) ) {
+			$values = array_unique( $values );
+		}
+
+		return $values;
+	}
 }

--- a/vendor/Custom-Meta-Boxes/class.cmb-meta-box.php
+++ b/vendor/Custom-Meta-Boxes/class.cmb-meta-box.php
@@ -44,6 +44,7 @@ class CMB_Meta_Box {
 			// If we are on a post edit screen - get metadata value of the field for this post
 			if ( $post_id ) {
 				$values = (array) get_post_meta( $post_id, $field['id'], false );
+				$values = apply_filters( 'cmb_admin_display_field_values_' . $field['type'] , $values );
 			}
 
 			if ( class_exists( $class ) ) {


### PR DESCRIPTION
### Requirements
Fixed the multiple select2 box bloat, causing slow pageloads.

### Description of the Change
- We have added in a filter to only allow unique IDS in the "post_select" array. Before its displayed on the administration screens.

### Before
![FireShot Capture 004 - Edit Tour “Tanzania Highlights   Zanzibar – 2025” ‹ The Safari Partne_ - www thesafaripartners com](https://github.com/lightspeedwp/tour-operator/assets/1805603/bffa91df-72be-459c-a392-342a3276d982)

### After
![Screenshot 2024-04-10 at 11 51 53](https://github.com/lightspeedwp/tour-operator/assets/1805603/9ff908ac-3395-4b8c-8f9e-c3cc4a1f274c)
