### PR TITLE
2.0.0 - Post Meta Updates + Price Block Variation

### DIFF
--- a/assets/js/blocks/variations.js
+++ b/assets/js/blocks/variations.js
@@ -90,18 +90,13 @@ wp.domReady(() => {
 		attributes: {
 			metadata: {
 				name: 'Price',
-				bindings: {
-					content: {
-						source: 'lsx/post-meta'
-					}
-				}
 			},
 			align: 'wide',
             layout: {
                 type: 'flex',
                 flexWrap: 'nowrap'
             },
-			className: 'facts-price-wrapper'
+			className: 'lsx-price-wrapper'
 		},
 		innerBlocks: [
 			[ 'core/paragraph', {

--- a/assets/js/blocks/variations.js
+++ b/assets/js/blocks/variations.js
@@ -1,85 +1,140 @@
 wp.domReady(() => {
-    wp.blocks.registerBlockVariation('core/group', {
-        name: 'lsx/itinerary',
-        title: 'Itinerary',
+	wp.blocks.registerBlockVariation('core/group', {
+		name: 'lsx/itinerary',
+		title: 'Itinerary',
 		icon: 'list-view',
-        attributes: {
-            metadata: {
-                name: 'Itinerary',
-                bindings: {
-                    content: {
-                        source: 'lsx/tour-itinerary'
-                    }
-                }
-            },
-            align: 'wide',
-            layout: {
-                type: 'constrained'
-            }
-        },
-        innerBlocks: [
-            ['core/paragraph', {
-                placeholder: 'Insert your Itinerary pattern here.',
+		attributes: {
+			metadata: {
+				name: 'Itinerary',
+				bindings: {
+					content: {
+						source: 'lsx/tour-itinerary'
+					}
+				}
+			},
+			align: 'wide',
+			layout: {
+				type: 'constrained'
+			}
+		},
+		innerBlocks: [
+			['core/paragraph', {
+				placeholder: 'Insert your Itinerary pattern here.',
 				align: 'center'
-            }]
-        ],
-        isDefault: false
-    });
+			}]
+		],
+		isDefault: false
+	});
 
-    wp.blocks.registerBlockVariation('core/group', {
-        name: 'lsx/accommodation-units',
-        title: 'Units',
+	wp.blocks.registerBlockVariation('core/group', {
+		name: 'lsx/accommodation-units',
+		title: 'Units',
 		icon : 'admin-multisite',
-        attributes: {
-            metadata: {
-                name: 'Units',
-                bindings: {
-                    content: {
-                        source: 'lsx/accommodation-units'
-                    }
-                }
-            },
-            align: 'wide',
-            layout: {
-                type: 'constrained'
-            }
-        },
-        innerBlocks: [
-            ['core/paragraph', {
-                placeholder: 'Insert your Room pattern here.',
+		attributes: {
+			metadata: {
+				name: 'Units',
+				bindings: {
+					content: {
+						source: 'lsx/accommodation-units'
+					}
+				}
+			},
+			align: 'wide',
+			layout: {
+				type: 'constrained'
+			}
+		},
+		innerBlocks: [
+			['core/paragraph', {
+				placeholder: 'Insert your Room pattern here.',
 				align: 'center'
-            }]
-        ],
-        isDefault: false
-    });
+			}]
+		],
+		isDefault: false
+	});
 
-    wp.blocks.registerBlockVariation('core/gallery', {
-        name: 'lsx/gallery',
-        title: 'TO Gallery',
+	wp.blocks.registerBlockVariation('core/gallery', {
+		name: 'lsx/gallery',
+		title: 'TO Gallery',
 		icon : 'admin-multisite',
-        attributes: {
-            metadata: {
-                name: 'TO Gallery',
-                bindings: {
-                    content: {
-                        source: 'lsx/gallery'
-                    }
-                }
+		attributes: {
+			metadata: {
+				name: 'TO Gallery',
+				bindings: {
+					content: {
+						source: 'lsx/gallery'
+					}
+				}
+			},
+			linkTo: 'none',
+			sizeSlug: 'thumbnail'
+		},
+		innerBlocks: [
+			['core/image', {
+				href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
+			}],
+			['core/image', {
+				href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
+			}],
+			['core/image', {
+				href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
+			}]
+		],
+		isDefault: false
+	});
+
+	wp.blocks.registerBlockVariation('core/group', {
+		name: 'lsx/price',
+		title: 'Price',
+		icon : 'bank',
+		attributes: {
+			metadata: {
+				name: 'Price',
+				bindings: {
+					content: {
+						source: 'lsx/post-meta'
+					}
+				}
+			},
+			align: 'wide',
+            layout: {
+                type: 'flex',
+                flexWrap: 'nowrap'
             },
-            linkTo: 'none',
-            sizeSlug: 'thumbnail'
-        },
-        innerBlocks: [
-            ['core/image', {
-                href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
-            }],
-            ['core/image', {
-                href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
-            }],
-            ['core/image', {
-                href: 'https://tour-operator.lsx.design/wp-content/plugins/tour-operator/assets/img/placeholders/placeholder-general-350x350.jpg'
-            }]
-        ],
-        isDefault: false
-    });
+			className: 'facts-price-wrapper'
+		},
+		innerBlocks: [
+			[ 'core/paragraph', {
+					padding: {
+						top: '2px',
+						bottom: '2px'
+					},
+					typography: { 
+						fontSize: 'x-small'
+					},
+					content : '<strong>From:</strong>',
+					className: 'has-x-small-font-size',
+				}
+			],
+			[ 'core/paragraph', {
+					metadata: {
+						bindings: {
+							content: {
+								source: 'lsx/post-meta',
+								args: { key: 'price' }
+							}
+						}
+					},
+					className: 'has-primary-color has-text-color has-link-color',
+					color: {
+						link: 'primary-700',
+						text: 'primary-700'
+					}
+				}
+			]
+		],
+		isDefault: false
+	});
+	
+
 });

--- a/includes/classes/class-tour-operator.php
+++ b/includes/classes/class-tour-operator.php
@@ -229,7 +229,7 @@ class Tour_Operator {
 		$this->settings   = Settings::init();
 		$this->setup      = Setup::init();
 		$this->bindings   = Bindings::init();
-		$this->variations = Variations::init();
+		$this->variations = new Variations();
 		$this->patterns   = Patterns::init();
 	}
 }

--- a/includes/classes/legacy/class-tour-operator.php
+++ b/includes/classes/legacy/class-tour-operator.php
@@ -607,7 +607,6 @@ class Tour_Operator {
 		if ( ! isset( $allowedtags['i'] ) ) {
 			$allowedtags['i'] = array();
 		}
-
 		$allowedtags['i']['aria-hidden']    = true;
 
 		if ( ! isset( $allowedtags['span'] ) ) {

--- a/includes/classes/legacy/class-tour.php
+++ b/includes/classes/legacy/class-tour.php
@@ -306,12 +306,9 @@ class Tour {
 			$tour_operator = tour_operator();
 			$currency      = '';
 
-			if ( is_object( $tour_operator ) && isset( $tour_operator->options['general'] ) && is_array( $tour_operator->options['general'] ) ) {
-
-				if ( isset( $tour_operator->options['general']['currency'] ) && ! empty( $tour_operator->options['general']['currency'] ) ) {
-					$currency = $tour_operator->options['general']['currency'];
-					$currency = '<span class="currency-icon ' . strtolower( $currency ) . '">' . $currency . '</span>';
-				}
+			if ( is_object( $tour_operator ) && isset( $tour_operator->options['currency'] ) && ! empty( $tour_operator->options['currency'] ) ) {
+				$currency = $tour_operator->options['currency'];
+				$currency = '<span class="currency-icon ' . strtolower( $currency ) . '">' . $currency . '</span>';
 			}
 
 			$value = $currency . $value;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -227,7 +227,11 @@ function lsx_to_itinerary_thumbnail( $size = 'lsx-thumbnail-square', $meta_key =
 				$thumbnail_src = $thumbnail[0];
 			}
 		} elseif ( ! empty( $tour_itinerary->itinerary[ $meta_key ] ) ) {
-			$accommodation_images = false;
+			$accommodation_images = [];
+
+			if ( is_string( $tour_itinerary->itinerary[ $meta_key ] ) ) {
+				$tour_itinerary->itinerary[ $meta_key ] = array( $tour_itinerary->itinerary[ $meta_key ] );
+			}
 
 			foreach ( $tour_itinerary->itinerary[ $meta_key ] as $accommodation_id ) {
 				$tour_itinerary->register_current_gallery( $accommodation_id, $meta_key );
@@ -252,7 +256,7 @@ function lsx_to_itinerary_thumbnail( $size = 'lsx-thumbnail-square', $meta_key =
 				}
 			}
 
-			if ( false !== $accommodation_images ) {
+			if ( ! empty( $accommodation_images ) ) {
 				$thumbnail_src = $accommodation_images[0];
 			}
 		}

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -309,12 +309,6 @@ function lsx_to_accommodation_single_content_bottom() {
 
 		lsx_to_gallery( '<section id="gallery" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-gallery' ) . '>' . esc_html__( 'Gallery', 'tour-operator' ) . '</h2><div id="collapse-gallery" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
 
-		if ( function_exists( 'lsx_to_videos' ) ) {
-			lsx_to_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		} elseif ( class_exists( 'Envira_Videos' ) ) {
-			lsx_to_envira_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		}
-
 		if ( function_exists( 'lsx_to_accommodation_specials' ) ) {
 			lsx_to_accommodation_specials();
 		}
@@ -408,12 +402,6 @@ function lsx_to_destination_single_content_bottom() {
 		lsx_to_country_regions();
 
 		lsx_to_gallery( '<section id="gallery" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-gallery' ) . '>' . esc_html__( 'Gallery', 'tour-operator' ) . '</h2><div id="collapse-gallery" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-
-		if ( function_exists( 'lsx_to_videos' ) ) {
-			lsx_to_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		} elseif ( class_exists( 'Envira_Videos' ) ) {
-			lsx_to_envira_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		}
 
 		lsx_to_destination_tours();
 
@@ -621,12 +609,6 @@ function lsx_to_tour_single_content_bottom() {
 		lsx_to_included_block();
 
 		lsx_to_gallery( '<section id="gallery" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-gallery' ) . '>' . esc_html__( 'Gallery', 'tour-operator' ) . '</h2><div id="collapse-gallery" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-
-		if ( function_exists( 'lsx_to_videos' ) ) {
-			lsx_to_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		} elseif ( class_exists( 'Envira_Videos' ) ) {
-			lsx_to_envira_videos( '<section id="videos" class="lsx-to-section ' . lsx_to_collapsible_class() . '"><h2 class="lsx-to-section-title lsx-to-collapse-title lsx-title" ' . lsx_to_collapsible_attributes( 'collapse-videos' ) . '>' . esc_html__( 'Videos', 'tour-operator' ) . '</h2><div id="collapse-videos" class="collapse in"><div class="collapse-inner">', '</div></div></section>' );
-		}
 
 		if ( function_exists( 'lsx_to_tour_specials' ) ) {
 			lsx_to_tour_specials();

--- a/includes/metaboxes/config-destination.php
+++ b/includes/metaboxes/config-destination.php
@@ -169,38 +169,6 @@ $metabox['fields'][] = array(
     ),
 );
 
-if ( class_exists( 'Envira_Gallery' ) ) {
-	$metabox['fields'][] = array(
-		'id'   => 'envira_title',
-		'name' => esc_html__( 'Envira Gallery', 'tour-operator' ),
-		'type' => 'title',
-	);
-
-	$metabox['fields'][] = array(
-		'id'         => 'envira_gallery',
-		'name'       => esc_html__( 'Envira Gallery', 'tour-operator' ),
-		'type'       => 'pw_multiselect',
-		'use_ajax'   => false,
-		'allow_none' => true,
-		'options'  => array(
-			'post_type_args' => 'envira',
-		),
-	);
-
-	if ( class_exists( 'Envira_Videos' ) ) {
-		$metabox['fields'][] = array(
-			'id'         => 'envira_video',
-			'name'       => esc_html__( 'Envira Video Gallery', 'tour-operator' ),
-			'type'       => 'pw_multiselect',
-			'use_ajax'   => false,
-			'allow_none' => true,
-			'options'  => array(
-				'post_type_args' => 'envira',
-			),
-		);
-	}
-}
-
 if ( ! isset( tour_operator()->options['display']['maps_disable'] ) && empty( tour_operator()->options['display']['maps_disable'] ) ) {
 	$metabox['fields'][] = array(
 		'id'   => 'location_title',

--- a/includes/metaboxes/config-tour.php
+++ b/includes/metaboxes/config-tour.php
@@ -233,38 +233,6 @@ $metabox['fields'][] = array(
     ),
 );
 
-if ( class_exists( 'Envira_Gallery' ) ) {
-	$metabox['fields'][] = array(
-		'id'   => 'envira_title',
-		'name' => esc_html__( 'Envira Gallery', 'tour-operator' ),
-		'type' => 'title',
-	);
-
-	$metabox['fields'][] = array(
-		'id'         => 'envira_gallery',
-		'name'       => esc_html__( 'Envira Gallery', 'to-galleries' ),
-		'type'       => 'pw_multiselect',
-		'use_ajax'   => false,
-		'allow_none' => true,
-		'options'  => array(
-			'post_type_args' => 'envira',
-		),
-	);
-
-	if ( class_exists( 'Envira_Videos' ) ) {
-		$metabox['fields'][] = array(
-			'id'         => 'envira_video',
-			'name'       => esc_html__( 'Envira Video Gallery', 'to-galleries' ),
-			'type'       => 'pw_multiselect',
-			'use_ajax'   => false,
-			'allow_none' => true,
-			'options'  => array(
-				'post_type_args' => 'envira',
-			),
-		);
-	}
-}
-
 $metabox['fields'][] = array(
 	'id'   => 'itinerary_title',
 	'name' => esc_html__( 'Itinerary', 'tour-operator' ),

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -282,38 +282,6 @@ function lsx_to_sharing() {
 	echo '</section>';
 }
 
-/**
- * Outputs the Envira Video Gallery
- *
- * @param       $before | string
- * @param       $after  | string
- * @param       $echo   | boolean
- * @return      string
- *
- * @package     tour-operator
- * @subpackage  template-tags
- * @category    tour
- */
-function lsx_to_envira_videos( $before = '', $after = '', $echo = true ) {
-	$envira_video = get_post_meta( get_the_ID(), 'envira_video', true );
-	$return = false;
-
-	if ( function_exists( 'envira_gallery' ) && ! empty( $envira_video ) ) {
-		// Envira Gallery
-		ob_start();
-		envira_gallery( $envira_video );
-		$return = ob_get_clean();
-
-		$return = $before . $return . $after;
-
-		if ( $echo ) {
-			echo wp_kses_post( $return );
-		} else {
-			return $return;
-		}
-	}
-}
-
 /* ==================  TAXONOMIES  ================== */
 
 /**


### PR DESCRIPTION
### Description
The following commit covers a few small changes designed at testing out the block variation creation and the visibility of post meta fields.

### Changes
- Removing the Envira Gallery Fields from all TO post types.
- Added in the price block variation, which will not show it contents on the frontend if the price meta is empty.

### Screenshots
![Screenshot 2024-10-18 at 10 56 23](https://github.com/user-attachments/assets/968ed7e5-f5a3-4012-a6ca-aacb9ad41883)
