### PR TITLE
2.0 WETU map embed block

### DIFF
--- a/assets/js/blocks/tour.js
+++ b/assets/js/blocks/tour.js
@@ -1,0 +1,51 @@
+wp.domReady(() => {
+
+	// WETU Map Embed
+	wp.blocks.registerBlockVariation('core/group', {
+		name: 'lsx-tour-operator/wetu-map',
+		title: 'WETU Map',
+		icon: 'admin-site',
+		category: 'lsx-tour-operator',
+		attributes: {
+			metadata: {
+				name: 'WETU Map',
+				bindings: {
+					content: {
+						source: 'lsx/map',
+						type: 'wetu'
+					}
+				},
+				style: {
+					spacing: {
+						margin: {
+							top: 0,
+							bottom: 0
+						},
+						padding: {
+							top: 0,
+							bottom: 0,
+							left: 0,
+							right: 0
+						}
+					}
+				},
+				layout: {
+					type: "constrained"
+				}
+			}
+		},
+		innerBlocks: [
+			[
+				"core/image",
+				{
+					align: "full",
+					sizeSlug: "large",
+					url: "https://tour-operator.lsx.design/wp-content/uploads/2024/09/wetu-map-figme-prototype-image.png",
+					alt: "",
+				}
+			]
+		],
+		isDefault: false,
+		allowedPostTypes: ['tour']
+	});
+});

--- a/assets/js/blocks/tour.js
+++ b/assets/js/blocks/tour.js
@@ -14,35 +14,46 @@ wp.domReady(() => {
 						source: 'lsx/map',
 						type: 'wetu'
 					}
-				},
-				style: {
-					spacing: {
-						margin: {
-							top: 0,
-							bottom: 0
-						},
-						padding: {
-							top: 0,
-							bottom: 0,
-							left: 0,
-							right: 0
-						}
-					}
-				},
-				layout: {
-					type: "constrained"
 				}
+			},
+			style: {
+				spacing: {
+					margin: {
+						top: 0,
+						bottom: 0
+					},
+					padding: {
+						top: "var:preset|spacing|x-small",
+						bottom: "var:preset|spacing|x-small",
+						left: 0,
+						right: 0
+					}
+				}
+			},
+			layout: {
+				type: "constrained"
 			}
 		},
 		innerBlocks: [
 			[
-				"core/image",
+				"core/group",
 				{
-					align: "full",
-					sizeSlug: "large",
-					url: "https://tour-operator.lsx.design/wp-content/uploads/2024/09/wetu-map-figme-prototype-image.png",
-					alt: "",
-				}
+					align: "wide",
+					layout:{
+						type:"default"
+					}
+				},
+				[
+					[
+						"core/image",
+						{
+							align: "full",
+							sizeSlug: "large",
+							url: "https://tour-operator.lsx.design/wp-content/uploads/2024/09/wetu-map-figme-prototype-image.png",
+							alt: "",
+						}
+					]
+				]
 			]
 		],
 		isDefault: false,

--- a/includes/classes/blocks/class-bindings.php
+++ b/includes/classes/blocks/class-bindings.php
@@ -91,7 +91,7 @@ class Bindings {
 		register_block_bindings_source(
 			'lsx/tour-itinerary',
 			array(
-				'label' => __( 'Tour Itinerary', 'lsx-wetu-importer' ),
+				'label' => __( 'Itinerary', 'lsx-wetu-importer' ),
 				'get_value_callback' => array( $this, 'itinerary_callback' )
 			)
 		);
@@ -99,7 +99,7 @@ class Bindings {
 		register_block_bindings_source(
 			'lsx/accommodation-units',
 			array(
-				'label' => __( 'Accommodation Units', 'lsx-wetu-importer' ),
+				'label' => __( 'Units', 'lsx-wetu-importer' ),
 				'get_value_callback' => array( $this, 'units_callback' )
 			)
 		);
@@ -107,8 +107,16 @@ class Bindings {
 		register_block_bindings_source(
 			'lsx/gallery',
 			array(
-				'label' => __( 'TO Gallery', 'lsx-wetu-importer' ),
-				'get_value_callback' => array( $this, 'gallery_callback' )
+				'label' => __( 'Gallery', 'lsx-wetu-importer' ),
+				'get_value_callback' => array( $this, 'empty_callback' )
+			)
+		);
+
+		register_block_bindings_source(
+			'lsx/map',
+			array(
+				'label' => __( 'Map', 'lsx-wetu-importer' ),
+				'get_value_callback' => array( $this, 'empty_callback' )
 			)
 		);
 	}
@@ -540,7 +548,7 @@ class Bindings {
 	 * 
 	 * @return string Returns an empty string if the block is of type 'core/group', otherwise no return value.
 	 */
-	public function gallery_callback( $source_args, $block_instance ) {
+	public function empty_callback( $source_args, $block_instance ) {
 		if ( 'core/group' === $block_instance->parsed_block['blockName'] ) {
 			return '';
 		}

--- a/includes/classes/blocks/class-bindings.php
+++ b/includes/classes/blocks/class-bindings.php
@@ -65,6 +65,7 @@ class Bindings {
 		add_filter( 'render_block', array( $this, 'render_itinerary_block' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'render_units_block' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'render_gallery_block' ), 10, 3 );
+		add_filter( 'render_block', array( $this, 'render_map_block' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'maybe_hide_varitaion' ), 10, 3 );
 	}
 
@@ -635,6 +636,58 @@ class Bindings {
 			$classes = implode( '', $matches[1] );
 		}
 		return $classes;
+	}
+
+	public function render_map_block( $block_content, $parsed_block, $block_obj ) {
+		// Determine if this is the custom block variation.
+		if ( ! isset( $parsed_block['blockName'] ) || ! isset( $parsed_block['attrs'] )  ) {
+			return $block_content;
+		}
+		$allowed_blocks = array(
+			'core/group'
+		);
+		$allowed_sources = array(
+			'lsx/map'
+		);
+
+		if ( ! in_array( $parsed_block['blockName'], $allowed_blocks, true ) ) {
+			return $block_content; 
+		}
+
+		do_action( 'qm/debug', $parsed_block['attrs']['metadata']['bindings']['content']['source'] );
+
+		if ( ! isset( $parsed_block['attrs']['metadata']['bindings']['content']['source'] ) ) {
+			return $block_content;
+		}
+
+		if ( ! in_array( $parsed_block['attrs']['metadata']['bindings']['content']['source'], $allowed_sources ) ) {
+			return $block_content;
+		}
+
+		$type = 'wetu';
+		if ( isset( $parsed_block['attrs']['metadata']['bindings']['content']['type'] ) ) {
+			$type = $parsed_block['attrs']['metadata']['bindings']['content']['type'];
+		}
+
+		do_action( 'qm/debug', $block_content );
+
+		$map = '';
+		switch ( $type ) {
+			case 'wetu':
+				$wetu_id = get_post_meta( get_the_ID(), 'lsx_wetu_id', true );
+				if ( ! empty( $wetu_id ) ) {
+					$map = '<iframe width="100%" height="500" frameborder="0" allowfullscreen="" class="wetu-map" class="block perfmatters-lazy entered pmloaded" data-src="https://wetu.com/Itinerary/VI/' . $wetu_id . '?m=bdep" data-ll-status="loaded" src="https://wetu.com/Itinerary/VI/c5ab6e23-b482-4256-b509-1069506fe1c2?m=bdep"></iframe>';
+				}
+			break;
+
+			default:
+			break;
+		}
+
+		$pattern       = '/<figure\b[^>]*>(.*?)<\/figure>/s';
+		$block_content = preg_replace( $pattern, $map, $block_content );
+
+		return $block_content;
 	}
 
 	/**

--- a/includes/classes/blocks/class-registration.php
+++ b/includes/classes/blocks/class-registration.php
@@ -38,6 +38,14 @@ class Registration {
 			);
 
 			wp_enqueue_script(
+				'lsx-to-block-tour-variations',  // Handle for the script.
+				LSX_TO_URL . 'assets/js/blocks/tour.js', // Path to your JavaScript file.
+				array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),  // Dependencies.
+				filemtime( LSX_TO_PATH . 'assets/js/blocks/tour.js' ), // Versioning with file modification time.
+				true  // Enqueue in the footer.
+			);
+
+			wp_enqueue_script(
 				'lsx-to-query-loops',  // Handle for the script.
 				LSX_TO_URL . 'assets/js/blocks/query-loops.js', // Path to your JavaScript file.
 				array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),  // Dependencies.


### PR DESCRIPTION
### Description of the Change
We have created a group block variation that will add in an image to the editor as a placeholder, and it will output the WETU map on the frontend.

### Screenshots
Add Block
![Screenshot 2024-11-05 at 16 00 01](https://github.com/user-attachments/assets/d3241bf1-b741-4e44-9254-528e4c809d64)
Frontend
![Screenshot 2024-11-05 at 16 22 32](https://github.com/user-attachments/assets/07a1da0a-48e8-4afd-983d-7e39cd8fe823)

Editor
![Screenshot 2024-11-05 at 15 59 53](https://github.com/user-attachments/assets/d8575c72-2b9f-460a-91f3-456d917641f2)

### Applicable Issues
#365 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new block variation for showcasing top-rated destinations.
	- Added functionality to enhance the WordPress cover block with link attributes.
	- Implemented custom toggle controls for post status in the editor.

- **Bug Fixes**
	- Improved image selection and deletion logic in the admin interface.
	- Enhanced multilingual support for "Read More" links.

- **Refactor**
	- Streamlined settings management and user interface for accommodations, destinations, and tours.
	- Restructured itinerary and accommodation handling for better data management.

- **Chores**
	- Updated changelog and documentation for clarity and accuracy.
	- Removed deprecated files and code for a cleaner codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->