### PR TITLE
Commit of LightBox fixes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -165,15 +165,19 @@
 }
 
 .slick-lightbox-close {
-  right: 32px;
-  top: 32px;
+  right: 52px;
+  top: 35px;
 }
+.slick-lightbox-close:before{font-size:40px;}
 
 .lsx-to-slider .slick-arrow,
 .slick-lightbox-inner .slick-arrow {
   background: transparent;
   border-radius: 50%;
+  position:absolute;
+  top:50%;
   border-style: solid;
+  border-color: #fff;
   border-width: 2px;
   font: 0/0 a;
   height: 4rem;
@@ -184,11 +188,15 @@
   transition: border 300ms ease;
   width: 4rem;
   z-index: 3;
+  color: white;
 }
+.slick-prev svg, .slick-next svg{color: white;}
+
 .lsx-to-slider .slick-arrow:before,
 .slick-lightbox-inner .slick-arrow:before {
   display: block;
-  font-family: "FontAwesome";
+  font-family: "slick";
+  color: white;
   font-size: 3rem;
   line-height: 1;
   position: absolute;
@@ -205,13 +213,21 @@
 }
 .lsx-to-slider .slick-arrow.slick-prev:before,
 .slick-lightbox-inner .slick-arrow.slick-prev:before {
-  content: "\f104";
-  left: 1.1rem;
+  content: ''; /* Remove font icon */
+    background: url('../img/left-arrow-new.svg') no-repeat center center;
+    width: 40px;
+    height: 40px;
+    display: inline-block;
+    left: 10px;
 }
 .lsx-to-slider .slick-arrow.slick-next:before,
 .slick-lightbox-inner .slick-arrow.slick-next:before {
-  content: "\f105";
-  left: 1.5rem;
+  content: ''; /* Remove font icon */
+    background: url('../img/right-arrow.svg') no-repeat center center;
+    width: 40px;
+    height: 40px;
+    display: inline-block;
+    left: 12px;
 }
 
 .lsx-to-slider .slick-dots:not(.dropdown-menu) {
@@ -269,3 +285,4 @@
   display: none;
 }
 /*# sourceMappingURL=style.css.map */
+

--- a/assets/img/left-arrow-new.svg
+++ b/assets/img/left-arrow-new.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="15 18 9 12 15 6"></polyline>
+</svg>

--- a/assets/img/left-arrow.svg
+++ b/assets/img/left-arrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="15 18 9 12 15 6"></polyline>
+</svg>

--- a/assets/img/right-arrow.svg
+++ b/assets/img/right-arrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#fff" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="9 6 15 12 9 18"></polyline>
+</svg>


### PR DESCRIPTION
**Gallery Tour Operator Light Box fixes.** 

Adjusted CSS and included SVG icons:

Display before: 
<img width="1983" alt="Screenshot 2024-12-06 at 10 31 28" src="https://github.com/user-attachments/assets/eccc1b5e-a4d3-4d10-b076-a640450f35de">


Display After CSS added: 
<img width="1395" alt="Screenshot 2024-12-06 at 10 31 03" src="https://github.com/user-attachments/assets/797eff76-5be4-42bd-9b51-8c552bc3b825">


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Updated the LightBox component with enhanced positioning and styling for a more intuitive user experience.
- New Feature: Introduced custom SVG icons in the LightBox component, replacing previous font icons for improved visual consistency and performance.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->