### PR TITLE
2.0.1 Parents only query args

### DIFF
--- a/assets/js/blocks/slider-query.js
+++ b/assets/js/blocks/slider-query.js
@@ -28,6 +28,15 @@
 				filterByOnsale = props.attributes.filterByOnsale;
 			}
 
+			var parentsOnly = props.attributes.parentsOnly || false;
+			if ( undefined === props.attributes.parentsOnly ) {
+				if ( props.attributes.className && props.attributes.className.includes( 'parents-only' ) ) {
+					parentsOnly = true;
+				}
+			} else {
+				parentsOnly = props.attributes.parentsOnly;
+			}
+
 			return el(
 				element.Fragment,
 				{},
@@ -50,6 +59,15 @@
 							onChange: function (value) {
 								props.setAttributes({
 									filterByOnsale: value
+								});
+							}
+						}),
+						el(CheckboxControl, {
+							label: 'Parents Only',
+							checked: parentsOnly,
+							onChange: function (value) {
+								props.setAttributes({
+									parentsOnly: value
 								});
 							}
 						})
@@ -85,6 +103,12 @@
 					extraProps.className = (extraProps.className || '') + ' on-sale';
 				} else if ( false === attributes.filterByOnsale && extraProps.className ) {
 					extraProps.className = extraProps.className.replace(/\bon-sale\b\s*/g, '').trim();
+				}
+
+				if ( true === attributes.parentsOnly ) {
+					extraProps.className = (extraProps.className || '') + ' parents-only';
+				} else if ( false === attributes.parentsOnly && extraProps.className ) {
+					extraProps.className = extraProps.className.replace(/\bparents-only\b\s*/g, '').trim();
 				}
 
 			}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [[2.0.1]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/2.0.1) - 
+
+### Added
+- A "Parents Only" checkbox to the TO query block settings, allowing you to select only the parent destinations.
+
 ## [[2.0.0]](https://github.com/lightspeeddevelopment/tour-operator/releases/tag/2.0.0) - 20-12-2024
 
 ### Enhancements

--- a/includes/classes/admin/class-admin.php
+++ b/includes/classes/admin/class-admin.php
@@ -22,19 +22,8 @@ class Admin {
 	 * LSX Tour Operator Admin constructor.
 	 */
 	public function __construct() {
-		add_filter( 'upload_mimes', array( $this, 'allow_svgimg_types' ) );
 		add_filter( 'type_url_form_media', array( $this, 'change_attachment_field_button' ), 20, 1 );
 		add_filter( 'plugin_action_links_' . plugin_basename( LSX_TO_CORE ), array( $this, 'add_action_links' ) );
-	}
-
-	/**
-	 * Allow SVG files for upload
-	 */
-	public function allow_svgimg_types( $mimes ) {
-		$mimes['svg'] = 'image/svg+xml';
-		$mimes['kml'] = 'image/kml+xml';
-
-		return $mimes;
 	}
 
 	/**

--- a/includes/classes/blocks/class-registration.php
+++ b/includes/classes/blocks/class-registration.php
@@ -128,10 +128,10 @@ class Registration {
 			$this->onsale = false;
 		}
 		
-		
 		if ( true === $this->parents_only ) {
 			$query['post_parent'] = 0;
 		}
+		
 
 		// Determine if this is the custom block variation.
 		if ( ! isset( $block['attrs']['className'] )  ) {

--- a/includes/classes/blocks/class-templates.php
+++ b/includes/classes/blocks/class-templates.php
@@ -81,23 +81,7 @@ class Templates {
 			'search-results' => [
 				'title'       => __( 'Search Results', 'tour-operator' ),
 				'description' => __( 'Displays when a visitor performs a search on your website.', 'tour-operator' ),
-			],
-			'index' => [
-				'title'       => __( 'Index', 'tour-operator' ),
-				'description' => __( 'Used as a fallback template for all pages when a more specific template is not defined.', 'tour-operator' ),
-			],
-			'no-title' => [
-				'title'       => __( 'No Title', 'tour-operator' ),
-				'description' => __( 'A generic page template with no page title displayed', 'tour-operator' ),
-			],
-			'pages' => [
-				'title'       => __( 'Pages', 'tour-operator' ),
-				'description' => __( 'A generic page template with a page title displayed', 'tour-operator' ),
-			],
-			'archive' => [
-				'title'       => __( 'All Archives', 'tour-operator' ),
-				'description' => __( 'Displays any archive, including posts by a single author, category, tag, taxonomy, custom post type, and date. This template will serve as a fallback when more specific templates (e.g., Category or Tag) cannot be found.', 'tour-operator' ),
-			],
+			]
 		];
 
 		foreach ( $post_types as $key => $labels ) {

--- a/includes/classes/legacy/class-destination.php
+++ b/includes/classes/legacy/class-destination.php
@@ -62,6 +62,7 @@ class Destination {
 		add_filter( 'lsx_to_custom_field_query', array( $this, 'travel_information_excerpt' ), 5, 10 );
 
 		add_action( 'wp_footer', array( $this, 'output_modals' ) );
+		
 	}
 
 	/**
@@ -113,6 +114,7 @@ class Destination {
 		}
 		return $countries;
 	}
+	
 
 	/**
 	 * Filter the travel information and return a shortened version.

--- a/includes/classes/legacy/class-destination.php
+++ b/includes/classes/legacy/class-destination.php
@@ -119,29 +119,18 @@ class Destination {
 
 	public function only_parent_destinations( $query ) {
 		// Only run on the front end and for the main query
-		if ( ! is_admin() && $query->is_main_query() ) {
-	
-			// If the query is for the 'destination' post type
-			$queried_post_type = $query->get( 'post_type' );
-	
-			// Sometimes it's an array, so normalize
-			if ( is_array( $queried_post_type ) ) {
-				$queried_post_type = reset( $queried_post_type );
-			}
-	
-			if ( 'destination' === $queried_post_type ) {
-				// Show only top-level
-				$query->set( 'post_parent', 0 );
-	
-				// Alphabetical by title
-				$query->set( 'orderby', 'title' );
-				$query->set( 'order', 'ASC' );
-	
-				// Make sure pagination is not disabled
-				$query->set( 'posts_per_page', 12 ); // or your desired number
-				$query->set( 'paged', get_query_var( 'paged' ) ); 
-				$query->set( 'nopaging', false );
-			}
+		if ( ! is_admin() && $query->is_main_query() && $query->is_post_type_archive( 'destination' ) ) {
+			// Show only top-level
+			$query->set( 'post_parent', 0 );
+
+			// Alphabetical by title
+			$query->set( 'orderby', 'title' );
+			$query->set( 'order', 'ASC' );
+
+			// Make sure pagination is not disabled
+			$query->set( 'posts_per_page', 12 ); // or your desired number
+			$query->set( 'paged', get_query_var( 'paged' ) ); 
+			$query->set( 'nopaging', false );
 		}
 	}
 	
@@ -161,7 +150,6 @@ class Destination {
 		}
 		return $args;
 	}
-	
 
 	/**
 	 * Filter the travel information and return a shortened version.

--- a/includes/classes/legacy/class-destination.php
+++ b/includes/classes/legacy/class-destination.php
@@ -60,6 +60,8 @@ class Destination {
 		add_filter( 'lsx_to_parents_only', array( $this, 'filter_countries' ) );
 
 		add_filter( 'lsx_to_custom_field_query', array( $this, 'travel_information_excerpt' ), 5, 10 );
+		add_filter( 'facetwp_query_args', [ $this, 'facet_wp_filter' ] , 10, 2 );
+		add_action( 'pre_get_posts', [ $this, 'only_parent_destinations' ] );
 
 		add_action( 'wp_footer', array( $this, 'output_modals' ) );
 		
@@ -113,6 +115,51 @@ class Destination {
 			$countries = array_reverse( $new_items );
 		}
 		return $countries;
+	}
+
+	public function only_parent_destinations( $query ) {
+		// Only run on the front end and for the main query
+		if ( ! is_admin() && $query->is_main_query() ) {
+	
+			// If the query is for the 'destination' post type
+			$queried_post_type = $query->get( 'post_type' );
+	
+			// Sometimes it's an array, so normalize
+			if ( is_array( $queried_post_type ) ) {
+				$queried_post_type = reset( $queried_post_type );
+			}
+	
+			if ( 'destination' === $queried_post_type ) {
+				// Show only top-level
+				$query->set( 'post_parent', 0 );
+	
+				// Alphabetical by title
+				$query->set( 'orderby', 'title' );
+				$query->set( 'order', 'ASC' );
+	
+				// Make sure pagination is not disabled
+				$query->set( 'posts_per_page', 12 ); // or your desired number
+				$query->set( 'paged', get_query_var( 'paged' ) ); 
+				$query->set( 'nopaging', false );
+			}
+		}
+	}
+	
+	/**
+	 * Sets the destination archive to only show top-level destinations
+	 *
+	 * @param array $args
+	 * @param array $facet
+	 * @return array
+	 */
+	public function facet_wp_filter( $args, $facet ) {
+		if ( is_post_type_archive( 'destination' ) ) {
+			$args['post_parent']   = 0;
+			$args['orderby']       = 'title';
+			$args['order']         = 'ASC';
+			$args['posts_per_page'] = 12;
+		}
+		return $args;
 	}
 	
 

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -61,7 +61,7 @@ class Frontend extends Tour_Operator {
 		}
 
 		// add_filter( 'the_terms', array( $this, 'links_new_window' ), 10, 2 );
-		$this->maps = Maps::get_instance();
+		//$this->maps = Maps::get_instance();
 
 		add_filter( 'get_the_archive_title', array( $this, 'get_the_archive_title' ), 100 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tour-operator",
-  "version": "1.4.9",
+  "version": "2.0.1",
   "description": "Tour Operators for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: lsx, tour operator, travel, tourism, itinerary
 Requires at least: 6.7
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/templates/archive-destination.html
+++ b/templates/archive-destination.html
@@ -29,8 +29,11 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"metadata":{"name":"Archive Content"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|medium","bottom":"var:preset|spacing|medium","left":"var:preset|spacing|x-small","right":"var:preset|spacing|x-small"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--medium);padding-right:var(--wp--preset--spacing--x-small);padding-bottom:var(--wp--preset--spacing--medium);padding-left:var(--wp--preset--spacing--x-small)"><!-- wp:query {"queryId":1,"query":{"perPage":6,"pages":"3","offset":"0","postType":"destination","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"parents":[]},"align":"wide","layout":{"type":"constrained","contentSize":""}} -->
-<div class="wp-block-query alignwide"><!-- wp:post-template {"lock":{"move":false,"remove":false},"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|small"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
+<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--medium);padding-right:var(--wp--preset--spacing--x-small);padding-bottom:var(--wp--preset--spacing--medium);padding-left:var(--wp--preset--spacing--x-small)">
+	
+<!-- wp:query {"queryId":1,"query":{"perPage":"9","pages":"3","offset":"0","postType":"tour","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"align":"wide","layout":{"type":"constrained","contentSize":""}} -->
+	
+<div class="wp-block-query alignwide parents-only"><!-- wp:post-template {"lock":{"move":false,"remove":false},"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|small"}},"layout":{"type":"grid","columnCount":3,"minimumColumnWidth":null}} -->
 <!-- wp:group {"metadata":{"name":"Destination Card"},"className":"is-style-shadow-sm","style":{"spacing":{"blockGap":"0px","padding":{"top":"0px","bottom":"0px","left":"0px","right":"0px"}},"border":{"radius":"8px"}},"backgroundColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group is-style-shadow-sm has-base-background-color has-background" style="border-radius:8px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2","linkTarget":"_blank","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}},"border":{"radius":{"topLeft":"8px","topRight":"8px"}}}} /-->
 

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -5,7 +5,7 @@
  * Description:       Showcase tours, destinations, and accommodations with digital itineraries, galleries, and integrated maps.
  * Author:            lightspeedwp
  * Author URI:        https://lightspeedwp.agency/
- * Version:           2.0.0
+ * Version:           2.0.1
  * Requires at least: 6.7
  * Tested up to:      6.7
  * Requires PHP:      8.0
@@ -24,7 +24,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_TO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_TO_CORE', __FILE__ );
 define( 'LSX_TO_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_TO_VER', '2.0.0' );
+define( 'LSX_TO_VER', '2.0.1' );
 
 // Post Expirator.
 define( 'LSX_TO_POSTEXPIRATOR_DATEFORMAT', esc_html__( 'l F jS, Y', 'tour-operator' ) );
@@ -32,9 +32,3 @@ define( 'LSX_TO_POSTEXPIRATOR_TIMEFORMAT', esc_html__( 'g:ia', 'tour-operator' )
 
 // Include bootstrapper and start plugin.
 require_once LSX_TO_PATH . 'tour-operator-bootstrap.php';
-
-// Register activation hook.
-/*register_activation_hook( LSX_TO_CORE, array(
-	'Tour_Operator',
-	'register_activation_hook',
-) );*/


### PR DESCRIPTION
### Description
We have added in a checkbox to the TO query loop block settings to allow you to select only the parents to be returned.
The query block handles the "default" and a "custom" query.

### Screenshots
![Screenshot 2025-01-07 at 15 54 29](https://github.com/user-attachments/assets/71ec601d-93f4-4816-92d7-ad0d97fe2c22)
![Screenshot 2025-01-07 at 15 54 34](https://github.com/user-attachments/assets/b709a96f-60ea-46d9-8326-0149e0d21be7)
![Screenshot 2025-01-07 at 21 33 30](https://github.com/user-attachments/assets/494ea7f1-a69c-4a45-b929-9f21b46ca4b9)
![Screenshot 2025-01-07 at 21 33 36](https://github.com/user-attachments/assets/48b4d070-9f7c-4dd2-a291-f6814b9d131e)