### PR TITLE
2.0.2 - Archive Redirects + Taxonomy Slugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 ### Added
 - The Itinerary Included and Excluded field handling and block output.
-- `lsx_to_wetu_map_url_params` filter to allow 3rd party pplugins to change the WETU map attributes and what shows.
+- `lsx_to_wetu_map_url_params` filter to allow 3rd party plugins to change the WETU map attributes and what shows.
+- Permalink Settings fields, to allow the URL change for Travel Styles, Accommodation Type, and Brands.
 
 ### Fixed
 - Fixed the output of the Special Interests -  - [BH-77](https://www.bugherd.com/projects/430995/tasks/77)

--- a/includes/classes/admin/class-admin.php
+++ b/includes/classes/admin/class-admin.php
@@ -24,6 +24,7 @@ class Admin {
 	public function __construct() {
 		add_filter( 'type_url_form_media', array( $this, 'change_attachment_field_button' ), 20, 1 );
 		add_filter( 'plugin_action_links_' . plugin_basename( LSX_TO_CORE ), array( $this, 'add_action_links' ) );
+		add_filter( 'content_model_post_type_args', [ $this, 'disable_archives_singles' ], 10, 1 );
 	}
 
 	/**
@@ -50,5 +51,20 @@ class Admin {
 		);
 
 		return array_merge( $links, $mylinks );
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @return void
+	 */
+	public function disable_archives_singles( $post_type_args ) {
+
+		$options = get_option( 'lsx_to_settings', [] );
+		if ( isset( $options['s'] ) ) {
+
+		}
+
+		return $post_type_args;
 	}
 }

--- a/includes/classes/admin/class-admin.php
+++ b/includes/classes/admin/class-admin.php
@@ -24,7 +24,7 @@ class Admin {
 	public function __construct() {
 		add_filter( 'type_url_form_media', array( $this, 'change_attachment_field_button' ), 20, 1 );
 		add_filter( 'plugin_action_links_' . plugin_basename( LSX_TO_CORE ), array( $this, 'add_action_links' ) );
-		add_filter( 'content_model_post_type_args', [ $this, 'disable_archives_singles' ], 10, 1 );
+		add_filter( 'content_model_post_type_args', [ $this, 'disable_archives_singles' ], 10, 2 );
 	}
 
 	/**
@@ -58,11 +58,15 @@ class Admin {
 	 *
 	 * @return void
 	 */
-	public function disable_archives_singles( $post_type_args ) {
+	public function disable_archives_singles( $post_type_args, $slug ) {
 
 		$options = get_option( 'lsx_to_settings', [] );
-		if ( isset( $options['s'] ) ) {
+		if ( isset( $options[ $slug . '_disable_archives' ] ) && '' !== $options[ $slug . '_disable_archives' ] ) {
+			$post_type_args['has_archive'] = false;
+		}
 
+		if ( isset( $options[ $slug . '_disable_single' ] ) && '' !== $options[ $slug . '_disable_single' ] ) {
+			$post_type_args['publicly_queryable'] = false;
 		}
 
 		return $post_type_args;

--- a/includes/classes/admin/class-permalinks.php
+++ b/includes/classes/admin/class-permalinks.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * LSX Tour Operator - Permalinks Main Class
+ *
+ * @package   lsx
+ * @author    LightSpeed
+ * @license   GPL-2.0+
+ * @link
+ * @copyright 2017 LightSpeedDevelopment
+ */
+
+namespace lsx\admin;
+
+/**
+ * Class Admin
+ *
+ * @package lsx\admin
+ */
+class Permalinks {
+
+	/**
+	 * Holds the default for the permalinks.
+	 *
+	 * @var array
+	 */
+	public $defaults = array(
+		'lsx_to_travel-style'        => '',
+		'lsx_to_accommodation-type'  => '',
+		'lsx_to_accommodation-brand' => '',
+	);
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_init', [ $this, 'register_permalink_settings' ] );
+		add_action( 'admin_init', [ $this, 'save_custom_permalink_fields' ], 20 );
+		add_filter( 'lsx_to_register_taxonomy_args', [ $this, 'apply_taxonomy_slugs' ], 10, 2 );
+	}
+
+	/**
+	 * Register the setting to save custom fields.
+	 */
+	public function register_permalink_settings() {
+		register_setting( 'permalink', 'lsx_to_slugs', array(
+			'type'              => 'array',
+			'sanitize_callback' => [ $this, 'sanitize_permalink_fields' ],
+			'default'           => $this->defaults,
+		) );
+
+		add_settings_section(
+			'lsx_to_permalink_section',
+			'', // no title, just fields
+			[ $this, 'permalink_fields' ],
+			'permalink'
+		);
+	}
+
+	/**
+	 * Sanitize the custom permalink fields before saving.
+	 *
+	 * @param array $input Raw input from the form.
+	 * @return array Sanitized input.
+	 */
+	public function sanitize_permalink_fields( $input ) {
+		$sanitized = array();
+
+		foreach ( $this->defaults as $key => $default ){
+			$sanitized[ $key ] = isset( $input[ $key ] ) ? sanitize_text_field( $input[ $key ] ) : '';
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Register new fields to the permalink settings page.
+	 */
+	public function permalink_fields() {
+		// Get existing options or defaults.
+		$options = get_option( 'lsx_to_slugs', $this->defaults );
+
+		$fields = [
+			'travel-style' => [
+				'label' => esc_html__( 'Travel Style', 'tour-operator' ),
+			],
+			'accommodation-type' => [
+				'label' => esc_html__( 'Accommodation Type', 'tour-operator' ),
+			],
+			'accommodation-brand' => [
+				'label' => esc_html__( 'Brand', 'tour-operator' ),
+			],
+		];
+
+		?>
+		<h2><?php esc_html_e( 'LSX Tour Operator', 'tour-operator' ); ?></h2>
+		<table class="form-table">
+			<p>Use the following fields to alter the base slug for the LSX Tour Operator taxonomies like <code><?php echo home_url();?>/travel-style/honeymoon/</code></p>
+			<?php
+				foreach ( $fields as $key => $field ) {
+					?>
+					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $field['label'] ); ?></label></th>
+						<td>
+							<input type="text" id="<?php echo esc_attr( $key ); ?>" name="lsx_to_slugs[lsx_to_<?php echo esc_attr( $key ); ?>]" value="<?php echo esc_attr( $options[ 'lsx_to_' . $key ] ); ?>" class="regular-text" />
+						</td>
+					</tr>
+					<?php
+				}
+			?>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Manually save the fields on permalink save
+	 *
+	 * @return void
+	 */
+	public function save_custom_permalink_fields() {
+		if (
+			isset( $_POST['lsx_to_slugs'] ) &&
+			is_array( $_POST['lsx_to_slugs'] ) &&
+			current_user_can( 'manage_options' )
+		) {
+			check_admin_referer( 'update-permalink' ); // default nonce for permalink page
+
+			$input     = $_POST['lsx_to_slugs'];
+			$sanitized = $this->sanitize_permalink_fields( $input );
+
+			update_option( 'lsx_to_slugs', $sanitized );
+		}
+	}
+
+	/**
+	 * Applies the taxonomy slugs.
+	 *
+	 * @param array $args
+	 * @param array $object_types
+	 * @return array
+	 */
+	public function apply_taxonomy_slugs( $args, $taxonomy ) {
+		$slug_options = get_option( 'lsx_to_slugs', $this->defaults );
+
+		foreach ( $slug_options as $key => $option ) {
+
+			if ( 'lsx_to_' . $taxonomy !== $key ) {
+				continue;
+			}
+
+			$args['rewrite']['slug'] = $option;
+		}
+
+		return $args;
+	}
+}

--- a/includes/classes/class-taxonomies.php
+++ b/includes/classes/class-taxonomies.php
@@ -36,8 +36,8 @@ class Taxonomies extends Frame {
 	 * @param array  $config The taxonomy config arguments.
 	 */
 	protected function register_object( $slug, $config ) {
+		$config['args'] = apply_filters( 'lsx_to_register_taxonomy_args', $config['args'], $slug );
 		register_taxonomy( $slug, $config['object_types'], $config['args'] );
 		$this->object[ $slug ] = get_taxonomy( $slug );
 	}
-
 }

--- a/includes/classes/class-tour-operator.php
+++ b/includes/classes/class-tour-operator.php
@@ -6,6 +6,7 @@ use lsx\admin\Admin;
 use lsx\admin\Pages;
 use lsx\admin\Settings;
 use lsx\admin\Setup;
+use lsx\admin\Permalinks;
 use lsx\blocks\Bindings;
 use lsx\blocks\Patterns;
 use lsx\blocks\Registration;
@@ -70,6 +71,14 @@ class Tour_Operator {
 	 * @var     \lsx\admin\Pages
 	 */
 	public $pages;
+
+	/**
+	 * Holds the Permalinks instance.
+	 *
+	 * @since   1.1.0
+	 * @var     \lsx\admin\Permalinks
+	 */
+	public $permalinks;
 
 	/**
 	 * Holds the Taxonomies instance.
@@ -217,6 +226,7 @@ class Tour_Operator {
 	public function setup() {
 		require_once( LSX_TO_PATH . 'vendor/content-models/create-content-model.php' );
 
+		$this->permalinks = new Permalinks();
 		$this->pages      = Pages::init();
 		$this->taxonomies = Taxonomies::init();
 		$this->admin      = new Admin();

--- a/includes/classes/legacy/class-accommodation.php
+++ b/includes/classes/legacy/class-accommodation.php
@@ -62,7 +62,7 @@ class Accommodation {
 	private function __construct() {
 		$this->is_wetu_active          = false;
 
-		$this->options = get_option( '_lsx-to_settings', false );
+		$this->options = get_option( 'lsx_to_settings', false );
 
 		$this->unit_types = array(
 			''       => esc_html__( 'None', 'tour-operator' ),

--- a/includes/classes/legacy/class-admin.php
+++ b/includes/classes/legacy/class-admin.php
@@ -55,7 +55,7 @@ class Admin extends Tour_Operator {
 	 * @access private
 	 */
 	public function __construct() {
-		$this->options = get_option( '_lsx-to_settings', false );
+		$this->options = get_option( 'lsx_to_settings', false );
 		$this->set_vars();
 
 		$this->videos = Video::get_instance();

--- a/includes/classes/legacy/class-destination.php
+++ b/includes/classes/legacy/class-destination.php
@@ -53,7 +53,7 @@ class Destination {
 	 * @access private
 	 */
 	private function __construct() {
-		$this->options = get_option( '_lsx-to_settings', false );
+		$this->options = get_option( 'lsx_to_settings', false );
 
 		add_action( 'lsx_to_map_meta', array( $this, 'content_meta' ) );
 		add_action( 'lsx_to_modal_meta', array( $this, 'content_meta' ) );

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -49,7 +49,7 @@ class Frontend extends Tour_Operator {
 	 * @access private
 	 */
 	public function __construct() {
-		$this->options = get_option( '_lsx-to_settings', false );
+		$this->options = get_option( 'lsx_to_settings', false );
 		$this->set_vars();
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_stylescripts' ), 1 );

--- a/includes/classes/legacy/class-placeholders.php
+++ b/includes/classes/legacy/class-placeholders.php
@@ -97,7 +97,7 @@ class Placeholders {
 			$size = 'lsx-thumbnail-wide';
 		}
 
-		$options      = get_option( '_lsx-to_settings', false );
+		$options      = get_option( 'lsx_to_settings', false );
 		$holdit_width = '';
 
 		if ( is_array( $size ) && 2 === count( $size ) ) {
@@ -165,7 +165,7 @@ class Placeholders {
 	 * The post default placeholder call.
 	 */
 	public function default_post_thumbnail( $meta, $post_id, $meta_key ) {
-		$options = get_option( '_lsx-to_settings', false );
+		$options = get_option( 'lsx_to_settings', false );
 
 		//This ensures our "super" placeholder will always show.
 		$placeholder = 'lsx-placeholder';
@@ -215,7 +215,7 @@ class Placeholders {
 	public function default_term_thumbnail( $meta, $post_id, $meta_key ) {
 
 		if ( 'thumbnail' === $meta_key ) {
-			$options     = get_option( '_lsx-to_settings', false );
+			$options     = get_option( 'lsx_to_settings', false );
 			$placeholder = 'lsx-placeholder';
 
 			//First Check for a default, then check if there is one set by post type.

--- a/includes/classes/legacy/class-tour.php
+++ b/includes/classes/legacy/class-tour.php
@@ -51,7 +51,7 @@ class Tour {
 	 * @access private
 	 */
 	private function __construct() {
-		$this->options = get_option( '_lsx-to_settings', false );
+		$this->options = get_option( 'lsx_to_settings', false );
 
 		if ( false !== $this->options && isset( $this->options[ $this->slug ] ) && ! empty( $this->options[ $this->slug ] ) ) {
 			$this->options = $this->options[ $this->slug ];

--- a/includes/template-tags/maps.php
+++ b/includes/template-tags/maps.php
@@ -218,7 +218,7 @@ if ( ! function_exists( 'lsx_to_display_fustion_tables' ) ) {
 	 * @subpackage template-tags
 	 */
 	function lsx_to_display_fustion_tables() {
-		$temp = get_option( '_lsx-to_settings', false );
+		$temp = get_option( 'lsx_to_settings', false );
 		if ( isset( $temp['fusion_tables_enabled'] ) ) {
 			return true;
 		} else {
@@ -235,7 +235,7 @@ if ( ! function_exists( 'lsx_to_fustion_tables_attr' ) ) {
 	 * @subpackage template-tags
 	 */
 	function lsx_to_fustion_tables_attr( $attribute, $default ) {
-		$temp = get_option( '_lsx-to_settings', false );
+		$temp = get_option( 'lsx_to_settings', false );
 
 		if ( false !== $temp && isset( $temp ) ) {
 			if ( isset( $temp[ 'fusion_tables_' . $attribute ] ) && ! empty( $temp[ 'fusion_tables_' . $attribute ] ) ) {

--- a/vendor/content-models/includes/runtime/class-content-model.php
+++ b/vendor/content-models/includes/runtime/class-content-model.php
@@ -190,6 +190,14 @@ final class Content_Model {
 			$post_type_args['hierarchical'] = true;
 			$post_type_args['supports'][]   = 'page-attributes';
 		}
+
+		$post_type_args = apply_filters( 'content_model_post_type_args', $post_type_args );
+
+		$options = get_option( 'lsx_to_settings', [] );
+		print_r('<pre>');
+		print_r($options);
+		print_r('</pre>');
+		die();
  
 		register_post_type(
 			$this->slug,

--- a/vendor/content-models/includes/runtime/class-content-model.php
+++ b/vendor/content-models/includes/runtime/class-content-model.php
@@ -191,13 +191,7 @@ final class Content_Model {
 			$post_type_args['supports'][]   = 'page-attributes';
 		}
 
-		$post_type_args = apply_filters( 'content_model_post_type_args', $post_type_args );
-
-		$options = get_option( 'lsx_to_settings', [] );
-		print_r('<pre>');
-		print_r($options);
-		print_r('</pre>');
-		die();
+		$post_type_args = apply_filters( 'content_model_post_type_args', $post_type_args, $this->slug );
  
 		register_post_type(
 			$this->slug,


### PR DESCRIPTION
### Description
This PR contains the updates to the Archive Redirects and the functionality to allow the user to change the Taxonomy Slugs.

### Commits
- The Archive redirects and single redirects now use the correct post type arg parameters to disable the relevant option.
- In a similar fashion the use can now alter the taxonomy slugs using the "Permalink" settings in WordPress.

### Screenshots
![Screenshot 2025-04-29 at 15 43 05](https://github.com/user-attachments/assets/0681b335-3b8f-4554-a20a-1436c908c7cd)
