### PR TITLE
Add filter for breadcrumb links in Frontend class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+#### Filters
+- **Breadcrumb Links Override** - added a `lsx_to_breadcrumb_links` filter in `Frontend::get_breadcrumb_links()`, applied to the final crumbs array before it is returned, to allow 3rd party plugins to alter or extend Tour Operator breadcrumb links.
+
 ### Fixed
 
 #### Query Loops

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -207,6 +207,8 @@ class Frontend extends Tour_Operator
 			$crumbs = $this->tour_breadcrumb_links($crumbs);
 		}
 
+		$crumbs = apply_filters( 'lsx_to_breadcrumb_links', $crumbs, $this );
+
 		return $crumbs;
 	}
 


### PR DESCRIPTION
## Summary
- Adds a new `lsx_to_breadcrumb_links` filter in `Frontend::get_breadcrumb_links()`, applied to the final crumbs array, so 3rd party plugins can alter/extend Tour Operator breadcrumb links.
- Updates `changelog.md` (Unreleased > Added > Filters) to document the new filter.

## Test plan
- [x] Confirm breadcrumbs render unchanged with no filter attached (default behaviour preserved)
- [x] Hook `lsx_to_breadcrumb_links` from a test plugin/mu-plugin and confirm the crumbs array can be modified/extended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new extension point that allows third-party plugins to customise the final Tour Operator breadcrumb links.
  - Plugins can now adjust breadcrumb entries before they are displayed, enabling more flexible navigation experiences.

- **Documentation**
  - Documented the new breadcrumb customisation option in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->