### PR TITLE
fix: reconcile version sources on 2.2.0, enforce in CI, and record the dependency work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Build block assets
         run: npm run build
 
+      # Guards against the plugin header, readme Stable tag, LSX_TO_VER and
+      # package.json drifting apart, which they had.
+      - name: Check version sources agree
+        run: npm run lint:version
+
       # --- PHP ---
       - uses: shivammathur/setup-php@v2
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,21 @@
 #### Requirements
 - **Minimum PHP version raised from 8.0 to 8.2** - PHP 8.0 and 8.1 have both reached end of life (2023-11-26 and 2025-12-31 respectively) and no longer receive security fixes. `Requires PHP` (plugin header, `composer.json`, `readme.txt`) now floors at 8.2, the earliest version still supported - matching what CI already tests against. `phpcs.xml.dist`'s PHPCompatibilityWP `testVersion` raised to match; confirmed no new compatibility findings from the change.
 
+#### Build toolchain
+- **Node engines aligned with the pinned LTS** - `.nvmrc` pins 24.20.0 (the current Krypton LTS) but `engines` allowed `node >=24.11.0` and `npm >=10.0.0`. Both now match the `.nvmrc`, so a contributor on an older 24.x or on npm 10 is told up front rather than finding out through a lockfile that will not reproduce.
+
+### Security
+
+#### Dependencies
+- **All 9 Dependabot alerts cleared** - every one was a transitive dev dependency of `@wordpress/scripts` or `copy-webpack-plugin`, with no direct dependency to bump, so one-package-at-a-time updates could not close them: each moved a single lockfile entry that the next `npm install` resolved straight back. They are now pinned with `overrides` in `package.json`, so the constraint is declared once and holds across lockfile regeneration.
+  - `fast-uri ^3.1.6` - 4 high: SSRF via malformed IPv6 normalisation and via repeated hostname percent-decoding, host confusion via percent-encoded scheme normalisation and via skipped IDN canonicalisation.
+  - `serialize-javascript ^7.0.5` - high RCE via `RegExp.flags` and `Date.prototype.toISOString()`, plus a moderate CPU-exhaustion DoS via crafted array-like objects.
+  - `markdownlint-cli ^0.49.1` - `@wordpress/scripts` depends on `markdownlint-cli@^0.31.1`, which drags in `markdown-it@12` and `minimatch@3.0.8`. Overriding the parent clears the `markdown-it` smartquotes ReDoS and the `minimatch` `matchOne` backtracking alerts with a coherent tree, rather than forcing 2026 packages into a 2022-era parent. Nothing in this plugin runs `lint-md-docs`.
+  - `sockjs > uuid ^11.1.1` - missing buffer bounds check in v3/v5/v6. Scoped to `sockjs` so the root `uuid` stays on 14.x for `@wordpress/blocks`.
+
+#### Tooling
+- **`npm run lint:css` runs again** - `.stylelintrc.json` extended `@humanmade/stylelint-config`, which is not installed, so stylelint aborted with a `ConfigurationError` before linting a single file. It now extends `@wordpress/stylelint-config`, already a dev dependency. The pre-existing rule violations this exposes are untouched and remain non-blocking, as `ci.yml` documents.
+
 ## [[2.2.0]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.2.0) - 2026-07-30
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -33,12 +33,12 @@
 - **Version drift now fails CI** - `npm run lint:version` (`scripts/check-version-sync.mjs`) asserts that the plugin header, the readme `Stable tag`, the version constant and `package.json` all agree, and runs on every push and pull request. It exits non-zero listing each source and its value, so these cannot drift apart again unnoticed.
 
 #### Build toolchain
-- **Node engines aligned with the pinned LTS** - `.nvmrc` pins 24.20.0 (the current Krypton LTS) but `engines` allowed `node >=24.11.0` and `npm >=10.0.0`. Both now match the `.nvmrc`, so a contributor on an older 24.x or on npm 10 is told up front rather than finding out through a lockfile that will not reproduce.
+- **Node and npm requirements brought up to date** - `.nvmrc` pins Node 24.20.0 (the current Krypton LTS), and `engines` now requires `node >=24.20.0` to match it. `.nvmrc` says nothing about npm, so the npm floor is set separately, raised from `>=10.0.0` to `>=11.0.0`. A contributor on an older 24.x or on npm 10 is now told up front rather than finding out through a lockfile that will not reproduce.
 
 ### Security
 
 #### Dependencies
-- **All 9 Dependabot alerts cleared** - every one was a transitive dev dependency of `@wordpress/scripts` or `copy-webpack-plugin`, with no direct dependency to bump, so one-package-at-a-time updates could not close them: each moved a single lockfile entry that the next `npm install` resolved straight back. They are now pinned with `overrides` in `package.json`, so the constraint is declared once and holds across lockfile regeneration.
+- **All 9 Dependabot alerts cleared** - every one was a transitive dev dependency of `@wordpress/scripts` or `copy-webpack-plugin`, with no direct dependency to bump, so one-package-at-a-time updates could not close them: each moved a single lockfile entry that the next `npm install` resolved straight back. They are now constrained with `overrides` in `package.json`, so the constraint is declared once and holds across lockfile regeneration. The values below are caret ranges, not exact pins: they set a patched floor and let npm resolve upwards within the major.
   - `fast-uri ^3.1.6` - 4 high: SSRF via malformed IPv6 normalisation and via repeated hostname percent-decoding, host confusion via percent-encoded scheme normalisation and via skipped IDN canonicalisation.
   - `serialize-javascript ^7.0.5` - high RCE via `RegExp.flags` and `Date.prototype.toISOString()`, plus a moderate CPU-exhaustion DoS via crafted array-like objects.
   - `markdownlint-cli ^0.49.1` - `@wordpress/scripts` depends on `markdownlint-cli@^0.31.1`, which drags in `markdown-it@12` and `minimatch@3.0.8`. Overriding the parent clears the `markdown-it` smartquotes ReDoS and the `minimatch` `matchOne` backtracking alerts with a coherent tree, rather than forcing 2026 packages into a 2022-era parent. Nothing in this plugin runs `lint-md-docs`.

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,10 @@
 #### Requirements
 - **Minimum PHP version raised from 8.0 to 8.2** - PHP 8.0 and 8.1 have both reached end of life (2023-11-26 and 2025-12-31 respectively) and no longer receive security fixes. `Requires PHP` (plugin header, `composer.json`, `readme.txt`) now floors at 8.2, the earliest version still supported - matching what CI already tests against. `phpcs.xml.dist`'s PHPCompatibilityWP `testVersion` raised to match; confirmed no new compatibility findings from the change.
 
+#### Versioning
+- **All version sources reconciled on 2.2.0** - the plugin header and the readme `Stable tag` read `2.2`, `LSX_TO_VER` read `2.2.0`, and `package.json` was further behind still at `2.1.2`. Only `2.2.0` has ever existed as a git tag, and `10up/action-wordpress-plugin-deploy` derives the WordPress.org SVN tag from the git tag, so `Stable tag: 2.2` pointed at a tag that was never created. All four sources now read `2.2.0`.
+- **Version drift now fails CI** - `npm run lint:version` (`scripts/check-version-sync.mjs`) asserts that the plugin header, the readme `Stable tag`, the version constant and `package.json` all agree, and runs on every push and pull request. It exits non-zero listing each source and its value, so these cannot drift apart again unnoticed.
+
 #### Build toolchain
 - **Node engines aligned with the pinned LTS** - `.nvmrc` pins 24.20.0 (the current Krypton LTS) but `engines` allowed `node >=24.11.0` and `npm >=10.0.0`. Both now match the `.nvmrc`, so a contributor on an older 24.x or on npm 10 is told up front rather than finding out through a lockfile that will not reproduce.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tour-operator",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Tour Operators for LSX",
   "author": "LightSpeed",
   "license": "ISC",
@@ -76,7 +76,8 @@
     "lint:all": "npm run lint:php && npm run lint:js && npm run lint:css && npm run lint:pkg-json && npm run lint:yaml:workflows",
     "format": "npm run lint:php:fix && wp-scripts format",
     "format:js": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
-    "generate-readme": "node .github/scripts/update-readme.js"
+    "generate-readme": "node .github/scripts/update-readme.js",
+    "lint:version": "node scripts/check-version-sync.mjs"
   },
   "overrides": {
     "linkify-it": "^5.0.2",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: tour operator, travel, itinerary, tours, destinations, accommodations, tou
 Requires at least: 6.7
 Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 2.2
+Stable tag: 2.2.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -40,9 +40,14 @@ if (!mainPhp) {
 	process.exit(1);
 }
 
-// readme.txt casing is inconsistent across these repos.
+// readme.txt casing is inconsistent across these repos. A missing readme is
+// recorded as a null source rather than skipped, so renaming or dropping it
+// fails this check instead of quietly removing WordPress.org release metadata
+// from the things being validated.
 const readme = fs.readdirSync(root).find((f) => f.toLowerCase() === 'readme.txt');
-if (readme) {
+if (!readme) {
+	sources.push({ file: 'readme.txt', field: 'Stable tag', value: null });
+} else {
 	const head = fs.readFileSync(path.join(root, readme), 'utf8').slice(0, 4096);
 	const match = head.match(/^\s*Stable tag\s*:\s*(\S+)\s*$/im);
 	sources.push({ file: readme, field: 'Stable tag', value: match ? match[1] : null });

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Assert that every place this plugin states its version agrees.
+ *
+ * WordPress reads the plugin header, wordpress.org reads readme.txt's
+ * "Stable tag", and tooling reads package.json. When they drift, the plugin
+ * ships one version while the release metadata claims another. This has
+ * happened repeatedly here, so it is checked in CI rather than by eye.
+ *
+ * Exits non-zero, listing every source and its value, when they disagree.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const sources = [];
+
+// package.json
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+sources.push({ file: 'package.json', field: 'version', value: pkg.version });
+
+// The main plugin file is the top-level .php carrying a Plugin Name header.
+const phpFiles = fs.readdirSync(root).filter((f) => f.endsWith('.php'));
+let mainPhp = null;
+for (const file of phpFiles) {
+	const head = fs.readFileSync(path.join(root, file), 'utf8').slice(0, 4096);
+	if (/^\s*\*?\s*Plugin Name\s*:/im.test(head)) {
+		mainPhp = file;
+		const match = head.match(/^\s*\*?\s*Version\s*:\s*(\S+)\s*$/im);
+		sources.push({
+			file,
+			field: 'Version header',
+			value: match ? match[1] : null,
+		});
+		break;
+	}
+}
+if (!mainPhp) {
+	console.error('No plugin file with a "Plugin Name" header found.');
+	process.exit(1);
+}
+
+// readme.txt casing is inconsistent across these repos.
+const readme = fs.readdirSync(root).find((f) => f.toLowerCase() === 'readme.txt');
+if (readme) {
+	const head = fs.readFileSync(path.join(root, readme), 'utf8').slice(0, 4096);
+	const match = head.match(/^\s*Stable tag\s*:\s*(\S+)\s*$/im);
+	sources.push({ file: readme, field: 'Stable tag', value: match ? match[1] : null });
+}
+
+// A version constant, if the plugin defines one.
+const constHead = fs.readFileSync(path.join(root, mainPhp), 'utf8');
+const constMatch = constHead.match(/define\(\s*'([A-Z0-9_]*_VER)'\s*,\s*'([^']+)'\s*\)/);
+if (constMatch) {
+	sources.push({ file: mainPhp, field: constMatch[1], value: constMatch[2] });
+}
+
+const missing = sources.filter((s) => !s.value);
+const values = [...new Set(sources.filter((s) => s.value).map((s) => s.value))];
+
+for (const s of sources) {
+	console.log(`  ${s.value ?? '(not found)'}\t${s.file} — ${s.field}`);
+}
+
+if (missing.length) {
+	console.error(`\nCould not read a version from: ${missing.map((m) => `${m.file} (${m.field})`).join(', ')}`);
+	process.exit(1);
+}
+
+if (values.length > 1) {
+	console.error(`\nVersion mismatch: found ${values.join(', ')}. All sources must agree.`);
+	process.exit(1);
+}
+
+console.log(`\nAll version sources agree on ${values[0]}.`);

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -6,7 +6,7 @@
  * Description:       Showcase tours, destinations, and accommodations with digital itineraries, galleries, and integrated maps.
  * Author:            lightspeedwp
  * Author URI:        https://lightspeedwp.agency/
- * Version:           2.2
+ * Version:           2.2.0
  * Requires at least: 6.7
  * Tested up to:      7.1
  * Requires PHP:      8.2


### PR DESCRIPTION
Two things: the changelog entry that the dependency and tooling work merged
without, and a proper fix for the version drift.

## Changelog

Adds the dependency, CI and tooling changes under `Unreleased`, in the format
this changelog already uses.

## Version drift, fixed rather than noted

The four places this plugin states its version disagreed:

| source | was | now |
| --- | --- | --- |
| plugin header | `2.2` | `2.2.0` |
| readme `Stable tag` | `2.2` | `2.2.0` |
| version constant | `2.2.0` | `2.2.0` |
| `package.json` | behind both | `2.2.0` |

`2.2.0` is the correct value: it is the only `2.2.x` tag that has ever
existed, and `10up/action-wordpress-plugin-deploy` derives the WordPress.org
SVN tag from the git tag. `Stable tag: 2.2` therefore pointed at a tag that was
never created.

## So it cannot drift again

`scripts/check-version-sync.mjs`, wired up as `npm run lint:version` and run in
CI on every push and pull request. It reads all four sources, prints each with
its value, and exits non-zero when they disagree:

```
  2.2.0	package.json — version
  2.2.0	tour-operator.php — Version header
  2.2.0	readme.txt — Stable tag
  2.2.0	tour-operator.php — LSX_TO_VER

All version sources agree on 2.2.0.
```

No release is cut here. The version numbers are corrected to describe what has
already shipped, and the dependency work itself remains dev-only, with no
shipped PHP or built asset changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the plugin version to 2.2.0 across its published version information.

- **Documentation**
  - Added changelog entries covering consistent versioning, supported Node.js tooling, dependency security updates, and restored CSS linting support.
  - Documented safeguards that detect mismatched version information before release.

- **Maintenance**
  - Improved automated checks to help ensure reliable, consistent plugin releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->