### PR TITLE
Fix fatal TypeError on relationship meta stored across multiple rows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,20 @@
 
 ### Added
 
+#### WP-CLI
+- **`wp tour-operator normalise-relationships`** - converts relationship meta held across multiple rows into the single serialised array in bulk, for sites that would otherwise wait for every affected post to be re-saved. Supports `--dry-run` and `--key=<key>` - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
+
 #### Filters
 - **Breadcrumb Links Override** - added a `lsx_to_breadcrumb_links` filter in `Frontend::get_breadcrumb_links()`, applied to the final crumbs array before it is returned, to allow 3rd party plugins to alter or extend Tour Operator breadcrumb links.
 
 ### Fixed
+
+#### Post Connections
+- **Fatal error when saving a post that drops a connection** - `remove_connected_id()` passed the raw result of `get_post_meta( $id, $key, true )` to `array_diff()`. Where the reciprocal relationship meta is stored as one row per connected ID rather than a single serialised array, that result is a string and PHP 8 raised `Uncaught TypeError: array_diff(): Argument #1 ($array) must be of type array, string given`, aborting the save and triggering WordPress recovery mode. Relationship meta is now read and written through a new `lsx\legacy\Relationship_Meta` helper that reads every row for a key and flattens both storage shapes - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
+- **Connections silently half-removed on multi-row meta** - disconnecting a post wrote the new list with a `$prev_value` argument, which restricts the update to rows matching the old value. On a key holding several rows only one was rewritten and the rest survived, leaving the connection partly in place. Relationship keys are now rewritten as a single serialised array, so a key in the older multi-row shape repairs itself the next time it is saved - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
+- **Warning when clearing every connection on a field** - the branch handling "all connections removed" iterated the previous values without the array normalisation applied elsewhere in `cpt_relations()`, warning `foreach() argument must be of type array|object` and skipping the cleanup when the meta was a scalar - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
+- **Editor showing only one connection on multi-row meta** - CMB2 reads meta as a single value, so a relationship field whose meta was stored as one row per connected ID displayed only the first connection, and saving wrote that one value over all the others. The connection fields now feed CMB2 every stored row via `cmb2_override_{$field_id}_meta_value` - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
+- **Row duplication on the edited post's own relationship key** - CMB2 saves with `update_post_meta()`, which rewrites every existing row for a key, so saving a post whose relationship meta was held across several rows produced that many rows each holding the full array. The key is now collapsed before CMB2 writes it - Issue [#1363](https://github.com/lightspeedwp/tour-operator/issues/1363)
 
 #### Data Integrity
 - **Fatal error deleting any post that has meta** - `Query_Loop` registered its four-argument `maybe_flush_featured_cache_on_meta_change()` callback on the legacy `deleted_postmeta` hook, which passes only the meta IDs. WordPress therefore called a four-argument method with one argument, raising `ArgumentCountError: Too few arguments`. Every path reaching `delete_metadata_by_mid()` fatalled, `wp_delete_post()` included, so deleting a post with any postmeta was a hard fatal regardless of the meta key - the callback's own `$meta_key` guard is never reached, because the error happens on invocation. Now uses the canonical `deleted_post_meta`, which passes four arguments - Issue [#1370](https://github.com/lightspeedwp/tour-operator/issues/1370)

--- a/includes/classes/legacy/class-admin.php
+++ b/includes/classes/legacy/class-admin.php
@@ -82,6 +82,14 @@ class Admin extends Tour_Operator
 			add_action('cmb2_pre_save_field', array($this, 'cpt_relations'), 2, 20);
 
 			$this->connections   = $this->create_post_connections();
+
+			// Relationship keys can be stored as one row per connected ID. CMB2 reads meta
+			// as a single value, which would show only the first row in the editor and then
+			// save that back over the rest, so feed it every row instead.
+			foreach ($this->connections as $connection_key) {
+				add_filter('cmb2_override_' . $connection_key . '_meta_value', array($this, 'connection_meta_value'), 10, 3);
+			}
+
 			$this->single_fields = apply_filters('lsx_to_search_fields', array());
 			$this->taxonomies    = apply_filters('lsx_to_taxonomies', $this->taxonomies);
 
@@ -182,14 +190,17 @@ class Admin extends Tour_Operator
 
 		if (in_array($field_id, $this->connections)) {
 			$connected_id    = get_the_ID();
-			$previous_values = get_post_meta($connected_id, $field_id, true);
+			$previous_values = Relationship_Meta::get_ids($connected_id, $field_id);
 			$remote_key      = $this->reverse_key($field_id);
 
+			// This runs before CMB2 writes the field. CMB2 saves with update_post_meta(),
+			// which rewrites every existing row for the key, so a key left in the legacy
+			// multi-row shape would come out as N rows each holding the full array.
+			// Collapsing it here means CMB2 has a single row to write over.
+			Relationship_Meta::save_ids($connected_id, $field_id, $previous_values);
+
 			if (isset($field->data_to_save[$field_id])) {
-				$new_values = $field->data_to_save[$field_id];
-				if (! is_array($new_values)) {
-					$new_values = [$new_values];
-				}
+				$new_values = Relationship_Meta::normalise($field->data_to_save[$field_id]);
 			} else {
 				$new_values = [];
 			}
@@ -202,10 +213,6 @@ class Admin extends Tour_Operator
 					}
 				}
 			} else {
-
-				if (! is_array($previous_values)) {
-					$previous_values = [$previous_values];
-				}
 
 				// Now determine if we added or removed any values.
 				$is_removing = array_diff($previous_values, $new_values);
@@ -227,6 +234,36 @@ class Admin extends Tour_Operator
 	}
 
 	/**
+	 * Supplies CMB2 with every stored ID for a relationship field.
+	 *
+	 * CMB2 reads meta as a single value, which returns only the first row when a
+	 * relationship key is stored as one row per connected ID. Without this the editor
+	 * shows a single connection and saving writes that one value over all the others.
+	 *
+	 * @param mixed $data      The value CMB2 would otherwise read.
+	 * @param int   $object_id The post being edited.
+	 * @param array $args      CMB2 field arguments.
+	 * @return mixed The connected IDs, or $data to leave CMB2's own lookup alone.
+	 */
+	public function connection_meta_value($data, $object_id, $args)
+	{
+		if (! isset($args['type'], $args['field_id']) || 'post' !== $args['type']) {
+			return $data;
+		}
+
+		$ids = Relationship_Meta::get_ids($object_id, $args['field_id']);
+
+		// Nothing stored: hand back untouched so CMB2 runs its own lookup and any
+		// configured default still applies. Only override when there is something
+		// its single-value read would have missed.
+		if (empty($ids)) {
+			return $data;
+		}
+
+		return $ids;
+	}
+
+	/**
 	 * Reverses the key for the remote_key slug.
 	 *
 	 * @param [type] $meta_key
@@ -239,7 +276,7 @@ class Admin extends Tour_Operator
 	}
 
 	/**
-	 * Remove the connected ID from the serialized array.
+	 * Remove the connected ID from the reciprocal relationship meta.
 	 *
 	 * @param int    $remote_id
 	 * @param int    $connected_id
@@ -248,30 +285,20 @@ class Admin extends Tour_Operator
 	 */
 	public function remove_connected_id($remote_id, $connected_id, $meta_key)
 	{
-		$prev = get_post_meta($remote_id, $meta_key, true);
-		if (! empty($prev)) {
-			$diff = array_diff($prev, array($connected_id));
-			update_post_meta($remote_id, $meta_key, $diff, $prev);
-		}
+		Relationship_Meta::remove_id($remote_id, $meta_key, $connected_id);
 	}
 
+	/**
+	 * Add the connected ID to the reciprocal relationship meta.
+	 *
+	 * @param int    $remote_id
+	 * @param int    $connected_id
+	 * @param string $meta_key
+	 * @return void
+	 */
 	public function add_connected_id($remote_id, $connected_id, $meta_key)
 	{
-		$prev = get_post_meta($remote_id, $meta_key, true);
-		// No Previous items detected.
-		if (false === $prev || empty($prev)) {
-			delete_post_meta($remote_id, $meta_key);
-			$test = add_post_meta($remote_id, $meta_key, array($connected_id), true);
-		} else {
-			if (! is_array($prev)) {
-				$new = array($prev);
-			} else {
-				$new = $prev;
-			}
-			$new[]   = $connected_id;
-			$new     = array_unique($new);
-			$updated = update_post_meta($remote_id, $meta_key, $new, $prev);
-		}
+		Relationship_Meta::add_id($remote_id, $meta_key, $connected_id);
 	}
 
 

--- a/includes/classes/legacy/class-relationship-cli.php
+++ b/includes/classes/legacy/class-relationship-cli.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * WP-CLI command for converting legacy relationship meta to the canonical shape.
+ *
+ * @package   \lsx\legacy\Relationship_CLI
+ * @author    LightSpeed
+ * @license   GPL3
+ * @link
+ * @copyright 2026 lightspeedwp
+ */
+
+namespace lsx\legacy;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Converts relationship keys stored as one row per connected ID into a single row
+ * holding a serialised array.
+ *
+ * Saving a post repairs its own relationship keys, so this command is only needed to
+ * clear the legacy shape in bulk rather than waiting for every post to be edited.
+ *
+ * @package \lsx\legacy\Relationship_CLI
+ * @author  LightSpeed
+ */
+class Relationship_CLI {
+
+	/**
+	 * Normalises relationship meta stored across multiple rows.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Report what would change without writing anything.
+	 *
+	 * [--key=<key>]
+	 * : Limit the run to a single relationship meta key.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp tour-operator normalise-relationships --dry-run
+	 *     wp tour-operator normalise-relationships --key=tour_to_destination
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function normalise_relationships( $args, $assoc_args ) {
+		global $wpdb;
+
+		$dry_run = isset( $assoc_args['dry-run'] );
+		$only    = isset( $assoc_args['key'] ) ? (string) $assoc_args['key'] : '';
+		// create_post_connections() is defined on the legacy Tour_Operator, not on the
+		// \lsx\Tour_Operator instance that the tour_operator() helper returns.
+		$keys = Tour_Operator::get_instance()->create_post_connections();
+
+		if ( '' !== $only ) {
+			if ( ! in_array( $only, $keys, true ) ) {
+				\WP_CLI::error( sprintf( '%s is not a relationship meta key.', $only ) );
+			}
+			$keys = array( $only );
+		}
+
+		$converted    = 0;
+		$rows_removed = 0;
+
+		foreach ( $keys as $key ) {
+			// Post IDs holding more than one row for this key, i.e. the legacy shape.
+			// A one-off migration query: there is no meta_query equivalent for "more than
+			// one row", and caching the result would defeat the point of the command.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$post_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s GROUP BY post_id HAVING COUNT(*) > 1",
+					$key
+				)
+			);
+
+			if ( empty( $post_ids ) ) {
+				continue;
+			}
+
+			foreach ( $post_ids as $post_id ) {
+				$post_id = (int) $post_id;
+				$before  = get_post_meta( $post_id, $key, false );
+				$ids     = Relationship_Meta::normalise( $before );
+
+				// Every row beyond the first is removed when the key is collapsed.
+				$rows_removed += count( $before ) - 1;
+				++$converted;
+
+				\WP_CLI::log(
+					sprintf(
+						'%spost %d %s: %d rows -> %d ids',
+						$dry_run ? '[dry-run] ' : '',
+						$post_id,
+						$key,
+						count( $before ),
+						count( $ids )
+					)
+				);
+
+				if ( ! $dry_run ) {
+					Relationship_Meta::save_ids( $post_id, $key, $ids );
+				}
+
+				// get_post_meta() caches every post it touches, and a full run covers
+				// thousands. Drop the runtime cache periodically so memory does not grow
+				// with the size of the site.
+				//
+				// The wp_cache_supports() check is not redundant: where a persistent
+				// drop-in does not implement flush_runtime(), some WordPress versions
+				// fall back to wp_cache_flush(), which would flush the whole shared
+				// object cache mid-migration. Skip the trim rather than risk that.
+				if ( 0 === $converted % 200
+					&& function_exists( 'wp_cache_flush_runtime' )
+					&& function_exists( 'wp_cache_supports' )
+					&& wp_cache_supports( 'flush_runtime' ) ) {
+					wp_cache_flush_runtime();
+				}
+			}
+		}
+
+		if ( 0 === $converted ) {
+			\WP_CLI::success( 'No relationship meta needed converting.' );
+			return;
+		}
+
+		\WP_CLI::success(
+			sprintf(
+				'%s %d post/key pairs (%d surplus rows removed).',
+				$dry_run ? 'Would convert' : 'Converted',
+				$converted,
+				$rows_removed
+			)
+		);
+	}
+}

--- a/includes/classes/legacy/class-relationship-meta.php
+++ b/includes/classes/legacy/class-relationship-meta.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Normalised storage for the post-to-post relationship meta.
+ *
+ * Relationship keys such as `tour_to_destination` have historically been written in two
+ * different shapes: a single row holding a serialised array of IDs, and one row per
+ * connected ID holding a bare scalar. Reading either shape with
+ * `get_post_meta( $id, $key, true )` returns only the first row, which is a string in the
+ * multi-row case, and writing with a `$prev_value` argument only rewrites the rows that
+ * match that value. This class reads every row regardless of shape and always writes back
+ * the single serialised array, so a mixed key repairs itself on the next save.
+ *
+ * @package   \lsx\legacy\Relationship_Meta
+ * @author    LightSpeed
+ * @license   GPL3
+ * @link
+ * @copyright 2026 lightspeedwp
+ */
+
+namespace lsx\legacy;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reads and writes the post-to-post relationship meta in a single canonical shape.
+ *
+ * @package \lsx\legacy\Relationship_Meta
+ * @author  LightSpeed
+ */
+class Relationship_Meta {
+
+	/**
+	 * Returns every connected ID stored against a relationship key.
+	 *
+	 * Reads all rows for the key, not just the first, and flattens any row that is itself
+	 * an array, so both the serialised-array and the one-row-per-ID shapes are handled.
+	 *
+	 * @param int    $object_id The post holding the relationship meta.
+	 * @param string $meta_key  The relationship meta key.
+	 * @return array<int, string> Unique connected IDs as strings, reindexed from zero.
+	 */
+	public static function get_ids( $object_id, $meta_key ) {
+		$object_id = absint( $object_id );
+
+		if ( empty( $object_id ) || '' === (string) $meta_key ) {
+			return array();
+		}
+
+		return self::normalise( get_post_meta( $object_id, $meta_key, false ) );
+	}
+
+	/**
+	 * Flattens an arbitrarily shaped meta value into a list of unique ID strings.
+	 *
+	 * Nested arrays are flattened, objects and nulls are discarded, and empty or zero IDs
+	 * are dropped so that `array_diff()` and `foreach` are always safe downstream.
+	 *
+	 * @param mixed $values A scalar, an array of scalars, or an array of arrays.
+	 * @return array<int, string> Unique IDs as strings, reindexed from zero.
+	 */
+	public static function normalise( $values ) {
+		if ( ! is_array( $values ) ) {
+			$values = array( $values );
+		}
+
+		$ids = array();
+
+		foreach ( $values as $value ) {
+			if ( is_array( $value ) ) {
+				$ids = array_merge( $ids, self::normalise( $value ) );
+				continue;
+			}
+
+			if ( null === $value || is_object( $value ) || is_bool( $value ) ) {
+				continue;
+			}
+
+			$value = trim( (string) $value );
+
+			if ( '' === $value || '0' === $value ) {
+				continue;
+			}
+
+			$ids[] = $value;
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Writes the connected IDs back as a single row holding a serialised array.
+	 *
+	 * Any pre-existing rows for the key are removed first, so a key that was previously
+	 * stored as one row per ID collapses to the canonical shape. Writing is skipped when
+	 * the stored value is already canonical and unchanged.
+	 *
+	 * @param int               $object_id The post holding the relationship meta.
+	 * @param string            $meta_key  The relationship meta key.
+	 * @param array<int, mixed> $ids       The connected IDs to store.
+	 * @return bool True when the meta reflects the requested IDs.
+	 */
+	public static function save_ids( $object_id, $meta_key, $ids ) {
+		$object_id = absint( $object_id );
+
+		if ( empty( $object_id ) || '' === (string) $meta_key ) {
+			return false;
+		}
+
+		$ids = self::normalise( $ids );
+		$raw = get_post_meta( $object_id, $meta_key, false );
+
+		if ( ! is_array( $raw ) ) {
+			$raw = array();
+		}
+
+		if ( empty( $ids ) ) {
+			if ( ! empty( $raw ) ) {
+				delete_post_meta( $object_id, $meta_key );
+			}
+			return true;
+		}
+
+		// Already stored as a single serialised array with exactly these IDs.
+		if ( 1 === count( $raw ) && is_array( $raw[0] ) && self::normalise( $raw[0] ) === $ids ) {
+			return true;
+		}
+
+		delete_post_meta( $object_id, $meta_key );
+
+		return (bool) add_post_meta( $object_id, $meta_key, $ids, true );
+	}
+
+	/**
+	 * Adds a connected ID to a relationship key.
+	 *
+	 * @param int        $object_id    The post holding the relationship meta.
+	 * @param string     $meta_key     The relationship meta key.
+	 * @param int|string $connected_id The ID to connect.
+	 * @return bool True when the meta reflects the requested IDs.
+	 */
+	public static function add_id( $object_id, $meta_key, $connected_id ) {
+		$connected = self::normalise( array( $connected_id ) );
+
+		if ( empty( $connected ) ) {
+			return false;
+		}
+
+		return self::save_ids(
+			$object_id,
+			$meta_key,
+			array_merge( self::get_ids( $object_id, $meta_key ), $connected )
+		);
+	}
+
+	/**
+	 * Removes a connected ID from a relationship key.
+	 *
+	 * @param int        $object_id    The post holding the relationship meta.
+	 * @param string     $meta_key     The relationship meta key.
+	 * @param int|string $connected_id The ID to disconnect.
+	 * @return bool True when the meta reflects the requested IDs.
+	 */
+	public static function remove_id( $object_id, $meta_key, $connected_id ) {
+		$ids = self::get_ids( $object_id, $meta_key );
+
+		if ( empty( $ids ) ) {
+			return false;
+		}
+
+		return self::save_ids(
+			$object_id,
+			$meta_key,
+			array_diff( $ids, self::normalise( array( $connected_id ) ) )
+		);
+	}
+}

--- a/tests/php/RelationshipMetaTest.php
+++ b/tests/php/RelationshipMetaTest.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ * Unit tests for lsx\legacy\Relationship_Meta.
+ *
+ * Runs without a WordPress install: the post meta functions are stubbed by an in-memory
+ * store that reproduces the row semantics of wp-includes/meta.php, including the fact
+ * that a key can hold several rows and that get_post_meta( ..., true ) returns only the
+ * first of them.
+ *
+ * @package Tour_Operator
+ * @subpackage Tests
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/**
+ * Minimal stand-in for the wp_postmeta table.
+ */
+class TO_Test_Meta_Store {
+
+	/**
+	 * Rows, keyed by object ID then meta key, each an ordered list of values.
+	 *
+	 * @var array<int, array<string, array<int, mixed>>>
+	 */
+	public static $rows = array();
+
+	/**
+	 * Number of add/delete operations performed since the last reset.
+	 *
+	 * @var int
+	 */
+	public static $writes = 0;
+
+	/**
+	 * Empties the store between tests.
+	 *
+	 * @return void
+	 */
+	public static function reset() {
+		self::$rows   = array();
+		self::$writes = 0;
+	}
+
+	/**
+	 * Seeds the rows for one key verbatim, bypassing the class under test.
+	 *
+	 * @param int               $object_id Object ID.
+	 * @param string            $meta_key  Meta key.
+	 * @param array<int, mixed> $values    One entry per database row.
+	 * @return void
+	 */
+	public static function seed( $object_id, $meta_key, array $values ) {
+		self::$rows[ $object_id ][ $meta_key ] = $values;
+	}
+
+	/**
+	 * Returns the raw rows for one key.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key  Meta key.
+	 * @return array<int, mixed>
+	 */
+	public static function rows( $object_id, $meta_key ) {
+		return self::$rows[ $object_id ][ $meta_key ] ?? array();
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	/**
+	 * @param mixed $maybeint Value to convert.
+	 * @return int
+	 */
+	function absint( $maybeint ) {
+		return abs( (int) $maybeint );
+	}
+}
+
+if ( ! function_exists( 'get_post_meta' ) ) {
+	/**
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key  Meta key.
+	 * @param bool   $single    Return the first row only.
+	 * @return mixed
+	 */
+	function get_post_meta( $object_id, $meta_key, $single = false ) {
+		$rows = TO_Test_Meta_Store::rows( $object_id, $meta_key );
+
+		if ( $single ) {
+			return $rows[0] ?? '';
+		}
+
+		return $rows;
+	}
+}
+
+if ( ! function_exists( 'add_post_meta' ) ) {
+	/**
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key  Meta key.
+	 * @param mixed  $value     Value to store.
+	 * @param bool   $unique    Refuse when the key already has a row.
+	 * @return int|false
+	 */
+	function add_post_meta( $object_id, $meta_key, $value, $unique = false ) {
+		$rows = TO_Test_Meta_Store::rows( $object_id, $meta_key );
+
+		if ( $unique && ! empty( $rows ) ) {
+			return false;
+		}
+
+		$rows[] = $value;
+		TO_Test_Meta_Store::seed( $object_id, $meta_key, $rows );
+		++TO_Test_Meta_Store::$writes;
+
+		return count( $rows );
+	}
+}
+
+if ( ! function_exists( 'delete_post_meta' ) ) {
+	/**
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key  Meta key.
+	 * @return bool
+	 */
+	function delete_post_meta( $object_id, $meta_key ) {
+		if ( isset( TO_Test_Meta_Store::$rows[ $object_id ][ $meta_key ] ) ) {
+			++TO_Test_Meta_Store::$writes;
+		}
+		unset( TO_Test_Meta_Store::$rows[ $object_id ][ $meta_key ] );
+		return true;
+	}
+}
+
+require_once dirname( __DIR__, 2 ) . '/includes/classes/legacy/class-relationship-meta.php';
+
+use lsx\legacy\Relationship_Meta;
+
+class RelationshipMetaTest extends TestCase {
+
+	const KEY = 'destination_to_accommodation';
+
+	protected function setUp(): void {
+		parent::setUp();
+		TO_Test_Meta_Store::reset();
+	}
+
+	/**
+	 * The reported fatal: a key stored as one row per ID must not reach array_diff() as a
+	 * string.
+	 */
+	public function test_remove_id_on_multi_row_scalar_meta_does_not_throw() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', '19817', '21339' ) );
+
+		// Reproduces the pre-fix read: a string, not an array.
+		$this->assertIsString( get_post_meta( 161, self::KEY, true ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, '19817' );
+
+		$this->assertSame( array( '163', '21339' ), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * Removing from multi-row data must not leave the untouched rows behind.
+	 */
+	public function test_remove_id_collapses_multi_row_meta_to_a_single_array_row() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', '19817', '21339' ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, '163' );
+
+		$rows = TO_Test_Meta_Store::rows( 161, self::KEY );
+		$this->assertCount( 1, $rows, 'The key should collapse to exactly one row.' );
+		$this->assertSame( array( '19817', '21339' ), $rows[0] );
+	}
+
+	/**
+	 * The already-canonical serialised-array shape keeps working.
+	 */
+	public function test_remove_id_on_single_array_row() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( array( '163', '19817' ) ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, '163' );
+
+		$this->assertSame( array( '19817' ), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * A key mixing both shapes is read whole and repaired.
+	 */
+	public function test_get_ids_flattens_mixed_shapes_and_deduplicates() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', array( '19817', '163' ), 21339 ) );
+
+		$this->assertSame(
+			array( '163', '19817', '21339' ),
+			Relationship_Meta::get_ids( 161, self::KEY )
+		);
+	}
+
+	/**
+	 * Removing the last ID deletes the key rather than leaving an empty array behind.
+	 */
+	public function test_remove_last_id_deletes_the_key() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163' ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, '163' );
+
+		$this->assertSame( array(), TO_Test_Meta_Store::rows( 161, self::KEY ) );
+		$this->assertSame( array(), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * Removing an ID that is not connected leaves the IDs intact.
+	 */
+	public function test_remove_unconnected_id_is_a_no_op_for_the_id_list() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', '19817' ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, '99999' );
+
+		$this->assertSame( array( '163', '19817' ), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * Adding to multi-row data collapses it instead of appending another row.
+	 */
+	public function test_add_id_collapses_multi_row_meta() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', '19817' ) );
+
+		Relationship_Meta::add_id( 161, self::KEY, 21339 );
+
+		$rows = TO_Test_Meta_Store::rows( 161, self::KEY );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( array( '163', '19817', '21339' ), $rows[0] );
+	}
+
+	/**
+	 * Adding to an empty key creates the canonical single row.
+	 */
+	public function test_add_id_to_empty_key() {
+		Relationship_Meta::add_id( 161, self::KEY, '163' );
+
+		$rows = TO_Test_Meta_Store::rows( 161, self::KEY );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( array( '163' ), $rows[0] );
+	}
+
+	/**
+	 * Adding an ID that is already connected must not duplicate it.
+	 */
+	public function test_add_existing_id_does_not_duplicate() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( array( '163', '19817' ) ) );
+
+		Relationship_Meta::add_id( 161, self::KEY, '163' );
+
+		$this->assertSame( array( '163', '19817' ), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * Integers and numeric strings are the same connection.
+	 */
+	public function test_int_and_string_ids_are_equivalent() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( 163, '19817' ) );
+
+		Relationship_Meta::remove_id( 161, self::KEY, 163 );
+
+		$this->assertSame( array( '19817' ), Relationship_Meta::get_ids( 161, self::KEY ) );
+	}
+
+	/**
+	 * Empty, zero and non-scalar entries are discarded rather than stored.
+	 */
+	public function test_normalise_discards_unusable_values() {
+		$this->assertSame(
+			array( '163' ),
+			Relationship_Meta::normalise( array( '', '0', 0, null, false, ' 163 ', new stdClass() ) )
+		);
+	}
+
+	/**
+	 * A scalar value is accepted wherever a list is expected.
+	 */
+	public function test_normalise_accepts_a_bare_scalar() {
+		$this->assertSame( array( '163' ), Relationship_Meta::normalise( '163' ) );
+	}
+
+	/**
+	 * Saving an unchanged canonical value must not rewrite the row.
+	 */
+	public function test_save_ids_skips_writing_when_already_canonical() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( array( '163', '19817' ) ) );
+		$before = TO_Test_Meta_Store::rows( 161, self::KEY );
+		TO_Test_Meta_Store::$writes = 0;
+
+		Relationship_Meta::save_ids( 161, self::KEY, array( '163', '19817' ) );
+
+		$this->assertSame( $before, TO_Test_Meta_Store::rows( 161, self::KEY ) );
+		$this->assertSame(
+			0,
+			TO_Test_Meta_Store::$writes,
+			'An unchanged canonical value should not be deleted and re-added.'
+		);
+	}
+
+	/**
+	 * Re-saving the same IDs over multi-row storage still collapses it, which is what
+	 * lets a legacy key repair itself when its post is saved.
+	 */
+	public function test_save_ids_collapses_multi_row_storage_even_when_ids_are_unchanged() {
+		TO_Test_Meta_Store::seed( 161, self::KEY, array( '163', '19817', '163' ) );
+
+		Relationship_Meta::save_ids( 161, self::KEY, Relationship_Meta::get_ids( 161, self::KEY ) );
+
+		$rows = TO_Test_Meta_Store::rows( 161, self::KEY );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( array( '163', '19817' ), $rows[0] );
+	}
+
+	/**
+	 * An invalid object ID is rejected rather than writing to object 0.
+	 */
+	public function test_invalid_object_id_is_rejected() {
+		$this->assertSame( array(), Relationship_Meta::get_ids( 0, self::KEY ) );
+		$this->assertFalse( Relationship_Meta::save_ids( 0, self::KEY, array( '163' ) ) );
+		$this->assertFalse( Relationship_Meta::add_id( 161, '', '163' ) );
+	}
+}

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -73,6 +73,14 @@ spl_autoload_register('tour_operator_autoload_class', true, false);
 // Init Plugin.
 tour_operator();
 
+// Relationship meta maintenance command.
+if (defined('WP_CLI') && WP_CLI) {
+	\WP_CLI::add_command(
+		'tour-operator normalise-relationships',
+		array(new \lsx\legacy\Relationship_CLI(), 'normalise_relationships')
+	);
+}
+
 /**
  * Include sticky menu block filters. This adds mobile section headers to group blocks.
  */


### PR DESCRIPTION
Fixes #1363

## The fatal

`remove_connected_id()` passed the result of `get_post_meta( $id, $key, true )` straight to `array_diff()`:

```php
$prev = get_post_meta( $remote_id, $meta_key, true );
if ( ! empty( $prev ) ) {
	$diff = array_diff( $prev, array( $connected_id ) ); // $prev can be a string
```

Relationship keys exist in two storage shapes: a single row holding a serialised array, and one row per connected ID holding a bare scalar. In the second shape the single read returns a **string**, and PHP 8 raises `TypeError: array_diff(): Argument #1 ($array) must be of type array, string given`. That aborts `wp_insert_post()`, so the editor save fails and WordPress sends its recovery-mode email.

Confirmed against real data before any code was written: the reciprocal posts returned `type=string` from the single read, 15 rows each holding 11 distinct IDs.

## Three more defects on the same path

Guarding the `array_diff()` call alone would have left:

1. **`$prev_value` half-applies the removal.** `update_post_meta( $id, $key, $diff, $prev )` adds `meta_value = $prev` to the `WHERE` clause (`wp-includes/meta.php`), so on a key with N rows exactly one row was rewritten and the other N-1 survived. Passing an empty `$prev_value` is no better: `update_metadata()` then loops every `meta_id` and writes the same value to all of them.
2. **`foreach` over a scalar.** The "all connections removed" branch iterated `$previous_values` without the `is_array()` normalisation the sibling branch performed.
3. **The editor only ever showed one connection.** CMB2 reads meta as a single value, so a field backed by multi-row meta displayed the first connection only, and saving wrote that value over all the others. This is why simply reading all rows on the local side would have been destructive — it would have treated rows the user never saw as deliberate disconnections.

## Approach

A new `lsx\legacy\Relationship_Meta` owns the storage shape:

- **Read** with `get_post_meta( $id, $key, false )` so every row is seen, flattening any row that is itself an array.
- **Normalise** to unique, non-empty, reindexed string IDs, so `array_diff()` and `foreach` are safe by construction rather than by scattered guards.
- **Write** by deleting the key and adding one row holding a single serialised array, skipping the write when the stored value is already canonical and unchanged.

`remove_connected_id()` and `add_connected_id()` become thin delegates and the now-redundant `is_array()` guards in `cpt_relations()` are gone.

Connection fields also feed CMB2 every stored row via `cmb2_override_{$field_id}_meta_value`, so the editor shows the true set. Because CMB2 saves with `update_post_meta()` — which rewrites *every* row for a key — the edited post's own key is collapsed before CMB2 writes it, otherwise a legacy post would come out as N rows each holding the full array. When nothing is stored the filter hands back untouched so CMB2's own lookup and any configured default still apply.

## Clearing the legacy shape

The above is lazy: a key is repaired only when a post referencing it is saved, so untouched posts keep their old rows indefinitely. So:

```
wp tour-operator normalise-relationships --dry-run
wp tour-operator normalise-relationships
wp tour-operator normalise-relationships --key=tour_to_destination
```

Dry-run against a real affected install: **1210 post/key pairs, 17111 surplus rows**. De-duplication is not incidental — the legacy rows contain repeats (one key held 35 rows for 18 distinct IDs).

## Test tooling

While adding tests I found `phpunit-simple.xml` was executing **nothing**. Its testsuite pointed at a `<directory>` with no `suffix` attribute, and PHPUnit only discovers files ending in `Test.php`, whereas the files here are named `Test*.php`. Every run reported "No tests executed" and `composer test` passed without testing anything — which is also why CI carried a hand-maintained file list.

- `suffix=".php"` set, matching the intent already visible in the existing `<exclude>` entries; the WordPress-integration suites are excluded explicitly.
- CI and the composer scripts now run the config instead of a file list. This alone raises the run from **29 tests to 48**: `TestQueryLoopFeaturedCache` was standalone-capable but had never been in CI's list.
- Removed the `<report>` block: configuring coverage output with no Xdebug/PCOV present makes PHPUnit emit a runner warning and **exit 1**. `composer test:coverage` passes the flag on the command line instead.

## Verification

- `composer test` — 48 tests, 97 assertions, exit 0 (15 new).
- `node scripts/check-version-sync.mjs` — passes; no version bump here, the entries go under `[Unreleased]`.
- The reported failure reproduced against the old code and confirmed fixed.
- The CLI command executed end-to-end in dry-run against a real affected install.
- PHPCS clean on both new files; `class-admin.php` violations drop 312 → 287.
- Semgrep `p/security-audit p/secrets p/php`: 0 findings.

## Notes for reviewers

- Every branch that touches `class-admin.php` (#682, #810, #1148) carries the identical unguarded `array_diff()` call and will need rebasing onto this.
- Unrelated, found while getting CI green: `npm ci` is broken on `main` (Babel 8 CLI against Babel 7 core). Already resolved on `develop`, raised as #1365 so it is not lost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `tour-operator normalise-relationships` WP-CLI command to consolidate and repair relationship data, with optional key filtering and dry-run reporting.

- **Bug Fixes**
  - Improved relationship handling for multiple connected items.
  - Prevented duplicate relationship entries.
  - Corrected connection removal and cleanup of empty relationships.
  - Improved relationship field loading and legacy data repair.

- **Documentation**
  - Added unreleased changelog entries covering the new command and relationship fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->