### PR TITLE
Add labeler.yml to main and run CI on pushes to it

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,220 @@
+# Org-wide Labeler Rules
+# All labeling, status, type, and standardization is handled by the unified labeling agent and workflow.
+# This file maps branch patterns and file changes to canonical labels as defined in labels.yml.
+
+# NOTE: Issue-based automation (template-driven labeling) is planned as Wave 5.1.2 work
+# (see .github/reports/issue-template-audit-2026-05-31.md for proposed rules).
+# The labeling agent must be updated to support issue-body pattern matching before these rules can be activated.
+# Branch status kick-off
+"status:needs-review":
+  - head-branch:
+      - "^feat/.*"
+      - "^fix/.*"
+      - "^docs?/.*"
+      - "^ai/.*"
+      - "^automation/.*"
+      - "^research/.*"
+      - "^(chore|build|refactor|test|perf|ci|release|hotfix|design|a11y|qa|content|seo|config|migrate|uat|proto|ds|api|schema|telemetry|i18n|revert|ops)/.*"
+
+# Type mapping (by branch)
+"type:feature":
+  - head-branch: ["^feat/.*"]
+"type:bug":
+  - head-branch: ["^fix/.*", "^hotfix/.*"]
+"type:documentation":
+  - head-branch: ["^docs/.*"]
+"type:chore":
+  - head-branch: ["^chore/.*"]
+"type:build":
+  - head-branch: ["^build/.*", "^ci/.*"]
+"type:refactor":
+  - head-branch: ["^refactor/.*"]
+"type:test":
+  - head-branch: ["^test/.*", "^qa/.*"]
+"type:performance":
+  - head-branch: ["^perf/.*"]
+"type:design":
+  - head-branch: ["^design/.*"]
+"type:a11y":
+  - head-branch: ["^a11y/.*"]
+"type:question":
+  - head-branch: ["^question/.*"]
+"type:support":
+  - head-branch: ["^support/.*"]
+"type:ai-ops":
+  - head-branch: ["^ai/.*"]
+"type:automation":
+  - head-branch: ["^automation/.*"]
+"type:research":
+  - head-branch: ["^research/.*"]
+
+  # Priority mapping (by branch)
+"priority:critical":
+  - head-branch: ["^hotfix/.*"]
+"priority:normal":
+  - head-branch: ["^feat/.*", "^fix/.*", "^docs/.*", "^chore/.*"]
+
+  # Area/component mapping (by file path)
+"area:block-editor":
+  - changed-files:
+      any-glob-to-any-file:
+        - "src/blocks/**"
+        - "src/block-editor/**"
+        - "**/block.json"
+
+"area:theme":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/theme.json"
+        - "**/templates/**"
+        - "**/patterns/**"
+        - "**/parts/**"
+        - "theme/**/*"
+
+"area:ci":
+  - changed-files:
+      any-glob-to-any-file:
+        - ".github/workflows/**"
+        - ".github/actions/**"
+        - "ci/**/*"
+
+"area:labels":
+  - changed-files:
+      any-glob-to-any-file:
+        - ".github/labels.yml"
+        - ".github/labeler.yml"
+        - ".github/issue-types.yml"
+        - "docs/ISSUE_LABELS.md"
+        - "docs/ISSUE_TYPES.md"
+        - "scripts/agents/labeling.agent.js"
+        - "scripts/agents/includes/*label*.js"
+
+"area:dependencies":
+  - changed-files:
+      any-glob-to-any-file:
+        - "package.json"
+        - "package-lock.json"
+        - "composer.json"
+        - "composer.lock"
+        - ".github/dependabot.yml"
+
+"area:security":
+  - changed-files:
+      any-glob-to-any-file:
+        - "SECURITY.md"
+        - ".github/workflows/*security*"
+        - "scripts/**/*security*"
+
+"area:a11y":
+  - changed-files:
+      any-glob-to-any-file:
+        - "docs/**/*accessib*"
+        - "**/*a11y*"
+
+"area:documentation":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.md"
+        - "docs/**"
+        - "README.md"
+        - "**/README.md"
+
+"area:tests":
+  - changed-files:
+      any-glob-to-any-file:
+        - "tests/**/*"
+        - "**/*.test.*"
+        - "**/*.spec.*"
+        - "**/__tests__/**"
+
+"area:scripts":
+  - changed-files:
+      any-glob-to-any-file:
+        - "scripts/**/*"
+        - "**/*.sh"
+        - "**/*.bash"
+
+"area:assets":
+  - changed-files:
+      any-glob-to-any-file:
+        - "assets/**/*"
+        - "images/**/*"
+        - "**/*.png"
+        - "**/*.jpg"
+        - "**/*.svg"
+
+"area:woocommerce":
+  - changed-files:
+      any-glob-to-any-file:
+        - "woocommerce/**/*"
+        - "**/woocommerce*.css"
+        - "**/woocommerce*.php"
+        - "**/woocommerce*.js"
+
+# Language labels
+"lang:php":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.php"
+        - "composer.json"
+        - "composer.lock"
+        - "phpunit.xml"
+
+"lang:js":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.{js,jsx,ts,tsx}"
+        - "package.json"
+        - "package-lock.json"
+        - "tsconfig.json"
+
+"lang:css":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.{css,scss,sass,less}"
+
+"lang:md":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.md"
+
+"lang:json":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.json"
+
+"lang:yaml":
+  - changed-files:
+      any-glob-to-any-file:
+        - "**/*.{yml,yaml}"
+
+# (Deliberately no direct changelog meta mapping; the labeling agent manages meta:needs-changelog)
+
+# Discussion labels (for reference/documentation)
+"discussion:announcement":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:showcase":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:community":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:feedback":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:support":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:sponsorship":
+  - changed-files:
+      any-glob-to-any-file: []
+
+"discussion:partnership":
+  - changed-files:
+      any-glob-to-any-file: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   pull_request:
   push:
-    branches: ["develop", "2.1-trunk"]
+    # main included so a broken dependency tree there is caught by CI rather than
+    # discovered by the next pull request opened against it. Push events use the
+    # workflow file from the pushed branch, so this has to be set on main itself,
+    # not only on develop.
+    branches: ["main", "develop", "2.1-trunk"]
 
 # Narrowed CI: gates on the checks that reliably pass today — block asset build
 # and the standalone PHPUnit suite. PHPCS runs but is non-blocking while the


### PR DESCRIPTION
Closes the two CI gaps specific to `main`.

## 1. `pr-labels` fails on every PR targeting main

`.github/labeler.yml` exists on `develop` but not here, so `actions/labeler` errors out:

```
The config file was not found at .github/labeler.yml
HttpError: Not Found
```

Copied **verbatim** from `develop` — confirmed byte-identical with `diff`. The rules are branch-pattern based (`head-branch` matches), so they behave the same on either branch and the two files cannot drift.

## 2. Pushes to main run no CI at all

The push trigger covered `develop` and `2.1-trunk` only. Push events use the workflow file **from the pushed branch**, so adding `main` to that list on `develop` does nothing for pushes to `main` — it has to be set here.

This is precisely how the Babel 8 peer conflict (#1365) went unnoticed: `main` was unbuildable and nothing ran until a PR was opened against it and the install step failed.

## Deliberately not ported from develop

| file | why |
|---|---|
| `.github/dependabot.yml` | Dependabot reads config from the **default branch only**, so `develop`'s copy is authoritative; a copy here would be dead weight |
| `project-meta-sync.yml` | unrelated to CI |
| `push-deploy.yml` | governs deployment — out of scope for a CI fix |

## Verification

- `yamllint` clean on both files apart from one pre-existing line-length warning on `ci.yml` (line 44 on `main`, line 48 here after the four added comment lines — confirmed present on `origin/main` before this change).
- Both files parse as valid YAML; `labeler.yml` yields 43 label rules, and `ci.yml` push branches are now `[main, develop, 2.1-trunk]`.
- This PR is its own proof for gap 1: `pr-labels` should pass here, where it failed on #1366.
